### PR TITLE
Bumping dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to this project will be documented in this file.
 
 *The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).*
 
+## [2.9.1] - 2021-04-15
+
+### Changed
+- Bumped snowflake-connector-python to 2.4.2 and relaxed the pip dependency to ~= (pick the latest patch release 2.4.X on install)
+- Bumped the docker container python version to 3.9 as snowflake-connector-python now supports this as of 2.4
+- Created a 'Dockerfile-src' for users wanting to build schemachange themselves from source in Docker
+
 ## [2.9.0] - 2021-04-02
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7
+FROM python:3.9
 
 RUN pip install schemachange
 

--- a/Dockerfile-src
+++ b/Dockerfile-src
@@ -1,0 +1,18 @@
+FROM python:3.9
+
+WORKDIR /build
+
+COPY schemachange /build/schemachange
+COPY requirements.txt setup.py README.md /build/
+
+RUN pip3 install --upgrade -r requirements.txt
+RUN pip3 install --upgrade setuptools wheel
+RUN python3 setup.py bdist_wheel
+
+
+FROM python:3.9
+
+COPY --from=0 /build/dist/schemachange-*-py3-none-any.whl /tmp/
+RUN pip3 install /tmp/schemachange-*-py3-none-any.whl && rm /tmp/schemachange-*-py3-none-any.whl
+
+ENTRYPOINT schemachange

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ CREATE TABLE IF NOT EXISTS SCHEMACHANGE.CHANGE_HISTORY
 
 In order to run schemachange you must have the following:
 
-* You will need to have a recent version of python 3 installed (not 3.9.x as of 1/19/21)
+* You will need to have a recent version of python 3 installed
 * You will need to have the latest [Snowflake Python driver installed](https://docs.snowflake.com/en/user-guide/python-connector-install.html)
 * You will need to create the change history table used by schemachange in Snowflake (see [Change History Table](#change-history-table) above for more details)
     * First, you will need to create a database to store your change history table (schemachange will not help you with this)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-snowflake-connector-python==2.3.6
+snowflake-connector-python==2.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-snowflake-connector-python==2.4.2
+snowflake-connector-python~=2.4.2

--- a/schemachange/cli.py
+++ b/schemachange/cli.py
@@ -13,7 +13,7 @@ from cryptography.hazmat.primitives.asymmetric import dsa
 from cryptography.hazmat.primitives import serialization
 
 # Set a few global variables here
-_schemachange_version = '2.9.0'
+_schemachange_version = '2.9.1'
 _metadata_database_name = 'METADATA'
 _metadata_schema_name = 'SCHEMACHANGE'
 _metadata_table_name = 'CHANGE_HISTORY'

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,8 @@ setup(
     entry_points={"console_scripts": ["schemachange=schemachange.cli:main"]},
     classifiers=[
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Operating System :: OS Independent",
     ],
     dependency_links=[],

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ test_requires = parse_requirements("requirements.txt", session="schemachange")
 
 setup(
     name="schemachange",
-    version="2.9.0",
+    version="2.9.1",
     author="jamesweakley/jeremiahhansen",
     description="A Database Change Management tool for Snowflake",
     long_description=long_description,


### PR DESCRIPTION
* snowflake-connector-python to 2.4.2 and allow pip to pick the latest patch release
* bumping python to 3.9
* removed 'dont use 3.9 warning'
* added 3.8 and 3.9 trove classifiers (not sure if you'd like them all, or just 'latest')
* added in a 'Dockerfile-src' that will build schemachange from src instead of just a 'pip install schemachange'

Fixes #36 