### PR TITLE
Prevent File Separator To Be Consumed By Version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to this project will be documented in this file.
 
 *The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).*
 
+## [2.9.4] - 2021-07-22
+
+### Changed
+- Use a lazy regex matching for splitting version tags
+- Solves the issue due to which the lib consumed extra file separators
+
+
 ## [2.9.3] - 2021-07-22
 
 ### Changed

--- a/schemachange/cli.py
+++ b/schemachange/cli.py
@@ -13,7 +13,7 @@ from cryptography.hazmat.primitives.asymmetric import dsa
 from cryptography.hazmat.primitives import serialization
 
 # Set a few global variables here
-_schemachange_version = '2.9.3'
+_schemachange_version = '2.9.4'
 _metadata_database_name = 'METADATA'
 _metadata_schema_name = 'SCHEMACHANGE'
 _metadata_table_name = 'CHANGE_HISTORY'

--- a/schemachange/cli.py
+++ b/schemachange/cli.py
@@ -145,7 +145,7 @@ def get_all_scripts_recursively(root_directory, verbose):
     for file_name in file_names:
       
       file_full_path = os.path.join(directory_path, file_name)
-      script_name_parts = re.search(r'^([V])(.+)__(.+)\.(?:sql|SQL)$', file_name.strip())
+      script_name_parts = re.search(r'^([V])(.+?)__(.+)\.(?:sql|SQL)$', file_name.strip())
       repeatable_script_name_parts = re.search(r'^([R])__(.+)\.(?:sql|SQL)$', file_name.strip())
 
       # Set script type depending on whether it matches the versioned file naming format

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ test_requires = parse_requirements("requirements.txt", session="schemachange")
 
 setup(
     name="schemachange",
-    version="2.9.3",
+    version="2.9.4",
     author="jamesweakley/jeremiahhansen",
     description="A Database Change Management tool for Snowflake",
     long_description=long_description,


### PR DESCRIPTION
Fixes #26
 - Regex used for version splitting from the filename was a greedy one.  It consumed the entire before the last dunder (double underscore).
 - Changing the version regex group to a non-greedy (lazy) solves the issue.