### PR TITLE
add support for private keys that are not encrypted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 *The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).*
 
+## [2.9.4] - 2021-08-12
+### Changed
+* Added support for unencrypted private keys
+  * `SNOWFLAKE_PRIVATE_KEY_PASSPHRASE` environment variable is no longer required if the key is not encrypted
+
 ## [2.9.3] - 2021-07-22
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ The Snowflake user password for `SNOWFLAKE_USER` is required to be set in the en
 _**DEPRECATION NOTICE**: The `SNOWSQL_PWD` environment variable is deprecated but currently still supported. Support for it will be removed in a later version of schemachange. Please use `SNOWFLAKE_PASSWORD` instead._
 
 #### Private Key Authentication
-The Snowflake user encrypted private key for `SNOWFLAKE_USER` is required to be in a file with the file path set in the environment variable `SNOWFLAKE_PRIVATE_KEY_PATH`. Additionally, the password for the encrypted private key file is required to be set in the environment variable `SNOWFLAKE_PRIVATE_KEY_PASSPHRASE`. These two environment variables must be set prior to calling the script. schemachange will fail if the `SNOWFLAKE_PRIVATE_KEY_PATH` and `SNOWFLAKE_PRIVATE_KEY_PASSPHRASE` environment variables are not set.
+The Snowflake user encrypted private key for `SNOWFLAKE_USER` is required to be in a file with the file path set in the environment variable `SNOWFLAKE_PRIVATE_KEY_PATH`. Additionally, the password for the encrypted private key file is required to be set in the environment variable `SNOWFLAKE_PRIVATE_KEY_PASSPHRASE`. If the variable is not set, schemachange will assume the private key is not encrypted. These two environment variables must be set prior to calling the script. Schemachange will fail if the `SNOWFLAKE_PRIVATE_KEY_PATH` is not set.
 
 ### Script Parameters
 

--- a/schemachange/cli.py
+++ b/schemachange/cli.py
@@ -204,14 +204,21 @@ def execute_snowflake_query(snowflake_database, query, snowflake_session_paramet
       session_parameters = snowflake_session_parameters
     )
   # If no password, try private key authentication
-  elif os.getenv("SNOWFLAKE_PRIVATE_KEY_PATH") is not None and os.getenv("SNOWFLAKE_PRIVATE_KEY_PATH") and os.getenv("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE") is not None and os.getenv("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"):
+  elif os.getenv("SNOWFLAKE_PRIVATE_KEY_PATH", ''):
     if verbose:
       print("Proceeding with private key authentication")
 
+    private_key_password = os.getenv("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE", '')
+    if private_key_password:
+      private_key_password = private_key_password.encode()
+    else:
+      private_key_password = None
+      if verbose:
+        print("No private key passphrase provided. Assuming the key is not encrypted.")
     with open(os.environ["SNOWFLAKE_PRIVATE_KEY_PATH"], "rb") as key:
       p_key= serialization.load_pem_private_key(
           key.read(),
-          password = os.environ['SNOWFLAKE_PRIVATE_KEY_PASSPHRASE'].encode(),
+          password = private_key_password,
           backend = default_backend()
       )
 

--- a/schemachange/cli.py
+++ b/schemachange/cli.py
@@ -13,7 +13,7 @@ from cryptography.hazmat.primitives.asymmetric import dsa
 from cryptography.hazmat.primitives import serialization
 
 # Set a few global variables here
-_schemachange_version = '2.9.3'
+_schemachange_version = '2.9.4'
 _metadata_database_name = 'METADATA'
 _metadata_schema_name = 'SCHEMACHANGE'
 _metadata_table_name = 'CHANGE_HISTORY'

--- a/schemachange/cli.py
+++ b/schemachange/cli.py
@@ -40,8 +40,8 @@ def schemachange(root_folder, snowflake_account, snowflake_user, snowflake_role,
 
   # Password authentication will take priority
   if "SNOWFLAKE_PASSWORD" not in os.environ and "SNOWSQL_PWD" not in os.environ:  # We will accept SNOWSQL_PWD for now, but it is deprecated
-    if "SNOWFLAKE_PRIVATE_KEY_PATH" not in os.environ or "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE" not in os.environ:
-      raise ValueError("Missing environment variable(s). SNOWFLAKE_PASSWORD must be defined for password authentication. SNOWFLAKE_PRIVATE_KEY_PATH and SNOWFLAKE_PRIVATE_KEY_PASSPHRASE must be defined for private key authentication.")
+    if "SNOWFLAKE_PRIVATE_KEY_PATH" not in os.environ:
+      raise ValueError("Missing environment variable(s). SNOWFLAKE_PASSWORD must be defined for password authentication. SNOWFLAKE_PRIVATE_KEY_PATH and (optional) SNOWFLAKE_PRIVATE_KEY_PASSPHRASE must be defined for private key authentication.")
 
   root_folder = os.path.abspath(root_folder)
   if not os.path.isdir(root_folder):

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ test_requires = parse_requirements("requirements.txt", session="schemachange")
 
 setup(
     name="schemachange",
-    version="2.9.3",
+    version="2.9.4",
     author="jamesweakley/jeremiahhansen",
     description="A Database Change Management tool for Snowflake",
     long_description=long_description,


### PR DESCRIPTION
Adressing issue
https://github.com/Snowflake-Labs/schemachange/issues/52

This change adds support for private keys which are not protected(encrypted) by passphrase. 
If passphrase is not provided, it is assumed the  key is not encrypted.