### PR TITLE
loosen and upgrade deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-snowflake-connector-python~=2.4.2
-pandas~=1.2.5
-pyyaml~=5.4.1
+snowflake-connector-python~=2.6
+pandas~=1.3
+pyyaml~=5.4


### PR DESCRIPTION
Running into issues using schemachange in a project which enforces version constraints properly.
I am using pandas 1.3 and the snowflake python connector 2.6 - this means schemachange **can't be installed** because it explicitly needs pandas <1.3 and the python connector <2.5 .

This PR relaxes the version constraints to only require matching major versions. Keeping it strict would requiring you guys to cut new versions whenever pandas or the snowflake connector publish a new minor version, which seems like needless work.

Additionally I've bumped the snowflake connector and pandas minor versions to make the intention clear, though technically there is no effect here on consumers due to the relaxed constraints.

Hope this is ok!