### PR TITLE
fix crash on dry run with no change history table

### DIFF
--- a/schemachange/cli.py
+++ b/schemachange/cli.py
@@ -97,6 +97,7 @@ def schemachange(config_folder, root_folder, snowflake_account, snowflake_user, 
   max_published_version = ''
 
   change_history = None
+  r_scripts_checksum = None
   if (config['dry-run'] and change_history_metadata) or not config['dry-run']:
     change_history = fetch_change_history(change_history_table, snowflake_session_parameters, config['autocommit'], config['verbose'])
     r_scripts_checksum = fetch_r_scripts_checksum(change_history_table, snowflake_session_parameters, config['autocommit'], config['verbose'])
@@ -137,7 +138,7 @@ def schemachange(config_folder, root_folder, snowflake_account, snowflake_user, 
       checksum_current = hashlib.sha224(content.encode('utf-8')).hexdigest()
 
       # check if R file was already executed
-      if script_name in list(r_scripts_checksum['script_name']):
+      if r_scripts_checksum and script_name in list(r_scripts_checksum['script_name']):
         checksum_last = list(r_scripts_checksum.loc[r_scripts_checksum['script_name'] == script_name, 'checksum'])[0]
       else:
         checksum_last = ''


### PR DESCRIPTION
In the case where we do a dry run and the change history table doesn't yet exist, we currently get a crash if doing an R script due to undefined `r_scripts_checksum`. PR contents are probably more illustrative :)

Cheers
Jarrad