### PR TITLE
Add "--explain-first" to run `explain` on statements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: Python tests
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8, 3.9]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install -e .[dev]
+      - name: Test with pytest
+        run: |
+          pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,10 +5,12 @@ on: [push]
 jobs:
   build:
 
-    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9]
+        github-runner: ['ubuntu-latest', 'windows-latest']
+
+    runs-on: ${{ matrix.github-runner }}
 
     steps:
       - uses: actions/checkout@v2

--- a/schemachange/cli.py
+++ b/schemachange/cli.py
@@ -167,7 +167,7 @@ def deploy_command(config):
         continue
 
     if config['explain-first']:
-      explain_change_script(script, config['vars'], config['snowflake-database'], snowflake_session_parameters, config['verbose'])
+      explain_change_script(script, content, config['vars'], config['snowflake-database'], snowflake_session_parameters, config['verbose'])
 
     print("Applying change script %s" % script['script_name'])
     if not config['dry-run']:
@@ -558,12 +558,11 @@ def apply_change_script(script, script_content, vars, default_database, change_h
   execute_snowflake_query(change_history_table['database_name'], query, snowflake_session_parameters, autocommit, verbose)
 
 
-def explain_change_script(script, vars, default_database, snowflake_session_parameters, verbose):
+def explain_change_script(script, content, vars, default_database, snowflake_session_parameters, verbose):
   '''
   Run "explain <statement>" for every <statement> in a script of <statement>; <statement>; ...
   This will throw an error if the explain fails, which will catch many issues with the script without needing to directly execute it.
   '''
-  content = get_script_contents_with_variable_replacement(script['script_full_path'], vars, verbose)
 
   content_io = io.StringIO(content)
   statements = snowflake.connector.util_text.split_statements(content_io)

--- a/schemachange/cli.py
+++ b/schemachange/cli.py
@@ -166,7 +166,7 @@ def deploy_command(config):
         continue
 
     if config['explain-first']:
-      explain_change_script(script, config['vars'], config['snowflake-database'], snowflake_session_parameters, config['autocommit'], config['verbose'])
+      explain_change_script(script, config['vars'], config['snowflake-database'], snowflake_session_parameters, config['verbose'])
 
     print("Applying change script %s" % script['script_name'])
     if not config['dry-run']:

--- a/schemachange/cli.py
+++ b/schemachange/cli.py
@@ -18,6 +18,7 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives.asymmetric import dsa
 from cryptography.hazmat.primitives import serialization
 import io
+from traceback import print_exc
 
 # Set a few global variables here
 _schemachange_version = '3.2.0'
@@ -566,9 +567,17 @@ def explain_change_script(script, vars, default_database, snowflake_session_para
 
   content_io = io.StringIO(content)
   statements = snowflake.connector.util_text.split_statements(content_io)
-  for s, _ in statements:
+  for n, (s, _) in enumerate(statements):
+      print(f'Explaining statement {n}...')
       explain = f"explain {s}"
-      execute_snowflake_query(default_database, explain, snowflake_session_parameters, False, verbose)
+      try:
+        execute_snowflake_query(default_database, explain, snowflake_session_parameters, False, verbose)
+      except:
+        if n == 0:
+          raise
+        else:
+          warnings.warn(f'Statement {n} failed, but allowing failures for n > 0.')
+          print_exc()
 
 
 def main():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,70 +3,127 @@ import sys
 import pytest
 import unittest.mock as mock
 import schemachange.cli 
+import tempfile
+from textwrap import dedent
 
-
-@pytest.mark.parametrize("args, expected", [
-    (["schemachange"], ('.', None, None, None, None, None, None, None, None, None, False, False, False, False)),
-    (["schemachange", "--config-folder", "test"], ('test', None, None, None, None, None, None, None, None, None, False, False, False, False)),
-    (["schemachange", "-f", '.'], ('.', '.', None, None, None, None, None, None, None, None, False, False, False, False)),     
-    (["schemachange", "--modules-folder", "modules-folder"], ('.', None, "modules-folder", None, None, None, None, None, None, None, False, False, False, False)),
-    (["schemachange", "--snowflake-account", "account"], ('.', None, None, "account", None, None, None, None, None, None, False, False, False, False)),
-    (["schemachange", "--snowflake-user", "user"], ('.', None, None, None, "user", None, None, None, None, None, False, False, False, False)),
-    (["schemachange", "--snowflake-role", "role"], ('.', None, None, None, None, "role", None, None, None, None, False, False, False, False)),
-    (["schemachange", "--snowflake-warehouse", "warehouse"], ('.', None, None, None, None, None, "warehouse", None, None, None, False, False, False, False)),
-    (["schemachange", "--snowflake-database", "database"], ('.', None, None, None, None, None, None, "database", None, None, False, False, False, False)),    
-    (["schemachange", "--change-history-table", "db.schema.table"], ('.', None, None, None, None, None, None, None, "db.schema.table", None, False, False, False, False)),    
-    (["schemachange", "--vars", '{"var1": "val"}'], ('.', None, None, None, None, None, None, None, None, {'var1' : 'val'}, False, False, False, False)),
-    (["schemachange", "--create-change-history-table"], ('.', None, None, None, None, None, None, None, None, None, True, False, False, False)),
-    (["schemachange", "--autocommit"], ('.', None, None, None, None, None, None, None, None, None, False, True, False, False)),
-    (["schemachange", "--verbose"], ('.', None, None, None, None, None, None, None, None, None, False, False, True, False)),
-    (["schemachange", "--dry-run"], ('.', None, None, None, None, None, None, None, None, None, False, False, False, True))       
-])
-def test_main_no_subcommand_given_arguments_make_sure_arguments_set_on_call( args, expected):
-    sys.argv = args
-    
-    with mock.patch("schemachange.cli.schemachange") as mock_schemachange:
-        schemachange.cli.main()
-        mock_schemachange.assert_called_once_with(*expected)
-
+DEFAULT_CONFIG = {
+    'root-folder': os.path.abspath('.'),
+    'modules-folder': None,
+    'snowflake-account': None,
+    'snowflake-user': None,
+    'snowflake-role':None,
+    'snowflake-warehouse': None,
+    'snowflake-database': None,
+    'change-history-table': None,
+    'vars': {},
+    'create-change-history-table': False,
+    'autocommit': False,
+    'verbose': False,
+    'dry-run': False,
+}
 
 @pytest.mark.parametrize("args, expected", [
-    (["schemachange", "deploy"], ('.', None, None, None, None, None, None, None, None, None, False, False, False, False)),
-    (["schemachange", "deploy", "--config-folder", "test"], ('test', None, None, None, None, None, None, None, None, None, False, False, False, False)),
-    (["schemachange", "deploy", "-f", '.'], ('.', '.', None, None, None, None, None, None, None, None, False, False, False, False)),     
-    (["schemachange", "deploy", "--modules-folder", "modules-folder"], ('.', None, "modules-folder", None, None, None, None, None, None, None, False, False, False, False)),
-    (["schemachange", "deploy", "--snowflake-account", "account"], ('.', None, None, "account", None, None, None, None, None, None, False, False, False, False)),
-    (["schemachange", "deploy", "--snowflake-user", "user"], ('.', None, None, None, "user", None, None, None, None, None, False, False, False, False)),
-    (["schemachange", "deploy", "--snowflake-role", "role"], ('.', None, None, None, None, "role", None, None, None, None, False, False, False, False)),
-    (["schemachange", "deploy", "--snowflake-warehouse", "warehouse"], ('.', None, None, None, None, None, "warehouse", None, None, None, False, False, False, False)),
-    (["schemachange", "deploy", "--snowflake-database", "database"], ('.', None, None, None, None, None, None, "database", None, None, False, False, False, False)),    
-    (["schemachange", "deploy", "--change-history-table", "db.schema.table"], ('.', None, None, None, None, None, None, None, "db.schema.table", None, False, False, False, False)),    
-    (["schemachange", "deploy", "--vars", '{"var1": "val"}'], ('.', None, None, None, None, None, None, None, None, {'var1' : 'val'}, False, False, False, False)),
-    (["schemachange", "deploy", "--create-change-history-table"], ('.', None, None, None, None, None, None, None, None, None, True, False, False, False)),
-    (["schemachange", "deploy", "--autocommit"], ('.', None, None, None, None, None, None, None, None, None, False, True, False, False)),
-    (["schemachange", "deploy", "--verbose"], ('.', None, None, None, None, None, None, None, None, None, False, False, True, False)),
-    (["schemachange", "deploy", "--dry-run"], ('.', None, None, None, None, None, None, None, None, None, False, False, False, True))
-       
+    (["schemachange"], DEFAULT_CONFIG),
+    (["schemachange", "deploy"], DEFAULT_CONFIG),
+    (["schemachange", "deploy", "-f", '.'],
+        {**DEFAULT_CONFIG, 'root-folder':os.path.abspath('.')}),
+    (["schemachange", "deploy", "--snowflake-account", "account"],
+        {**DEFAULT_CONFIG, 'snowflake-account': 'account'}),
+    (["schemachange", "deploy", "--snowflake-user", "user"],
+        {**DEFAULT_CONFIG, 'snowflake-user': 'user'}),
+    (["schemachange", "deploy", "--snowflake-role", "role"],
+        {**DEFAULT_CONFIG, 'snowflake-role': 'role'}),
+    (["schemachange", "deploy", "--snowflake-warehouse", "warehouse"],
+        {**DEFAULT_CONFIG, 'snowflake-warehouse': 'warehouse'}),
+    (["schemachange", "deploy", "--snowflake-database", "database"],
+        {**DEFAULT_CONFIG, 'snowflake-database': 'database'}),
+    (["schemachange", "deploy", "--change-history-table", "db.schema.table"],
+        {**DEFAULT_CONFIG, 'change-history-table': 'db.schema.table'}),
+    (["schemachange", "deploy", "--vars", '{"var1": "val"}'],
+        {**DEFAULT_CONFIG, 'vars': {'var1' : 'val'},}),
+    (["schemachange", "deploy", "--create-change-history-table"],
+        {**DEFAULT_CONFIG, 'create-change-history-table': True}),
+    (["schemachange", "deploy", "--autocommit"],
+        {**DEFAULT_CONFIG, 'autocommit': True}),
+    (["schemachange", "deploy", "--verbose"],
+        {**DEFAULT_CONFIG, 'verbose': True}),
+    (["schemachange", "deploy", "--dry-run"],
+        {**DEFAULT_CONFIG, 'dry-run': True}),
 ])
+
 def test_main_deploy_subcommand_given_arguments_make_sure_arguments_set_on_call( args, expected):
     sys.argv = args
     
-    with mock.patch("schemachange.cli.schemachange") as mock_schemachange:
+    with mock.patch("schemachange.cli.deploy_command") as mock_deploy_command:
         schemachange.cli.main()
-        mock_schemachange.assert_called_once_with(*expected)
+        mock_deploy_command.assert_called_once()
+        [config,], _call_kwargs = mock_deploy_command.call_args
+        assert config == expected
 
+@pytest.mark.parametrize("args, to_mock, expected_args", [
+    (["schemachange", "deploy", "--config-folder", "DUMMY"],
+        "schemachange.cli.deploy_command",
+        ({**DEFAULT_CONFIG, 'snowflake-account': 'account'},)),
+    (["schemachange", "render", "script.sql", "--config-folder", "DUMMY"],
+        "schemachange.cli.render_command",
+        ({**DEFAULT_CONFIG, 'snowflake-account': 'account'}, "script.sql"))
+])
+def test_main_deploy_config_folder(args, to_mock, expected_args):
+    with tempfile.TemporaryDirectory() as d:
+        with open(os.path.join(d, 'schemachange-config.yml'), 'wt') as f:
+            f.write(dedent('''
+                snowflake-account: account
+            '''))
+
+        args[args.index("DUMMY")] = d
+        sys.argv = args
+
+        with mock.patch(to_mock) as mock_command:
+            schemachange.cli.main()
+            mock_command.assert_called_once()
+            call_args, _call_kwargs = mock_command.call_args
+            assert call_args == expected_args
+
+
+@pytest.mark.parametrize("args, to_mock, expected_args", [
+    (["schemachange", "deploy", "--modules-folder", "DUMMY"],
+        "schemachange.cli.deploy_command",
+        ({**DEFAULT_CONFIG, 'modules-folder': 'DUMMY'},)),
+    (["schemachange", "render", "script.sql", "--modules-folder", "DUMMY"],
+        "schemachange.cli.render_command",
+        ({**DEFAULT_CONFIG, 'modules-folder': 'DUMMY'}, "script.sql"))
+])
+def test_main_deploy_modules_folder(args, to_mock, expected_args):
+    with tempfile.TemporaryDirectory() as d:
+
+        args[args.index("DUMMY")] = d
+        expected_args[0]['modules-folder'] = d
+        sys.argv = args
+
+        with mock.patch(to_mock) as mock_command:
+            schemachange.cli.main()
+            mock_command.assert_called_once()
+            call_args, _call_kwargs = mock_command.call_args
+            assert call_args == expected_args
 
 @pytest.mark.parametrize("args, expected", [
-    (["schemachange", "render", "script.sql"], ('.', None, None, None, False, "script.sql")),
-    (["schemachange", "render", "--config-folder", "test", "script.sql"], ("test", None, None, None, False, "script.sql")),
-    (["schemachange", "render", "--root-folder", '.', "script.sql"], ('.', ".", None, None, False, "script.sql")),
-    (["schemachange", "render", "--modules-folder", "modules-folder", "script.sql"], ('.', None, "modules-folder", None, False, "script.sql")),
-    (["schemachange", "render", "--vars", '{"var1": "val"}', "script.sql"], ('.', None, None, {'var1' : 'val'}, False, "script.sql")),
-    (["schemachange", "render", "--verbose", "script.sql"], ('.', None, None, None, True, "script.sql")),      
+    (["schemachange", "render", "script.sql"],
+        ({**DEFAULT_CONFIG}, "script.sql")),
+    # (["schemachange", "render", "--config-folder", "test", "script.sql"],
+    #     ("test", None, None, None, False, "script.sql")),
+    (["schemachange", "render", "--root-folder", '.', "script.sql"],
+        ({**DEFAULT_CONFIG, 'root-folder': os.path.abspath('.')}, "script.sql")),
+    #(["schemachange", "render", "--modules-folder", "modules-folder", "script.sql"], ('.', None, "modules-folder", None, False, "script.sql")),
+    (["schemachange", "render", "--vars", '{"var1": "val"}', "script.sql"],
+        ({**DEFAULT_CONFIG, 'vars': {"var1": "val"}}, "script.sql")),
+    (["schemachange", "render", "--verbose", "script.sql"],
+        ({**DEFAULT_CONFIG, 'verbose': True}, "script.sql")),
 ])
 def test_main_render_subcommand_given_arguments_make_sure_arguments_set_on_call( args, expected):
     sys.argv = args
     
     with mock.patch("schemachange.cli.render_command") as mock_render_command:
         schemachange.cli.main()
-        mock_render_command.assert_called_once_with(*expected)
+        mock_render_command.assert_called_once()
+        call_args, _call_kwargs = mock_render_command.call_args
+        assert call_args == expected

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -20,6 +20,7 @@ DEFAULT_CONFIG = {
     'autocommit': False,
     'verbose': False,
     'dry-run': False,
+    'explain-first': False
 }
 
 
@@ -50,6 +51,8 @@ DEFAULT_CONFIG = {
         {**DEFAULT_CONFIG, 'verbose': True}),
     (["schemachange", "deploy", "--dry-run"],
         {**DEFAULT_CONFIG, 'dry-run': True}),
+    (["schemachange", "deploy", "--explain-first"],
+        {**DEFAULT_CONFIG, 'explain-first': True}),
 ])
 def test_main_deploy_subcommand_given_arguments_make_sure_arguments_set_on_call( args, expected):
     sys.argv = args


### PR DESCRIPTION
At our org, we like to run `explain` on DDL statements before running them. With the notable exception of GRANT, this is supported on almost all DDL statements we normally have deal with, and serves as a very capable pre-check step, e.g. for us to run in feature branch CI runs or as a pre-commit hook. (with EXPLAIN, snowflake not only checks sql syntax, but also column, table, and function references, type compatibility, and probably more)

This pr adds an `--explain-first` flag to schemachange that will run `explain <statement>` before running any statements, which enables the above workflow. This also works with dry runs.

One drawback is that not all statements support EXPLAIN - e.g. I have hit GRANT statements but there might be others. Currently this PR is an all-or-nothing approach. This is still useful for us but I could see future work enabling this on a per-statement basis. This is non-trivial though, might need to add a magic var, comment, or something else to the sql code. Would seek your design input before doing anything in this direction.

Sorry for the bombardment of PRs, this is the last one! :)

Will squash before merging, just will await feedback first in case there are other changes / you don't like this direction / etc.

Cheers
Jarrad