### PR TITLE
3.2.2: fix tests, add CI, Argv as args to main() .

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: Python tests
+
+on: [push]
+
+jobs:
+  build:
+
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8, 3.9]
+        github-runner: ['ubuntu-latest', 'windows-latest']
+
+    runs-on: ${{ matrix.github-runner }}
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install -e .[dev]
+      - name: Test with pytest
+        run: |
+          pytest
+      - name: Test run
+        run: |
+          schemachange --help

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 *The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).*
 
+## [3.2.2] - 2021-11-06
+### Added
+- Restored CLI tests, hopefully less fragile now.
+- Added Github CI workflow to run unit tests and a basic execution test.
+- `schemachange.cli.main` is now defined as `def main(argv: List[str]=sys.argv)`, to allow consumers to pass a list of arguments easily.
 
 ## [3.2.1] - 2021-11-04
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,14 +14,14 @@ All notable changes to this project will be documented in this file.
 - Jinja Template Engine was not recognising scripts in subfolders on windows machines. Jinja was expecting the paths to follow a unix style ie SQL/V2.0.0__ADHOC_SCRIPT.sql but on windows machines this was being passed through as SQL\V2.0.0__ADHOC_SCRIPT.sql.
 
 ### Removed
-- Removed fragile unit tests in test_main.py. 
+- Removed fragile unit tests in test_main.py.
 
 ## [3.2.0] - 2021-10-28
 ### Added
 - Added support for jinja templates. Any file ending .sql or .sql.jinja will be processed using the [Jinja engine](https://jinja.palletsprojects.com/)
   - Added a new optional parameter `--modules-folder` to specify where common jinja template, macro or include files reside
 - Added new subcommands render and deploy
-  - The render command can be used to display the final script to the command line. 
+  - The render command can be used to display the final script to the command line.
   - The existing functionality moved to a new deploy subcommand
   - Fall back behaviour to assume deploy sub command if none provided
 - Added reserved variable name `schemachange` and an error will now be raised if supplied by the user via --vars

--- a/schemachange/cli.py
+++ b/schemachange/cli.py
@@ -555,7 +555,7 @@ def apply_change_script(script, script_content, vars, default_database, change_h
   execute_snowflake_query(change_history_table['database_name'], query, snowflake_session_parameters, autocommit, verbose)
 
 
-def main():
+def main(argv=sys.argv):
   parser = argparse.ArgumentParser(prog = 'schemachange', description = 'Apply schema changes to a Snowflake account. Full readme at https://github.com/Snowflake-Labs/schemachange', formatter_class = argparse.RawTextHelpFormatter)
   subcommands = parser.add_subparsers(dest='subcommand')
 
@@ -585,7 +585,7 @@ def main():
 
   # The original parameters did not support subcommands. Check if a subcommand has been supplied
   # if not default to deploy to match original behaviour.
-  args = sys.argv[1:]
+  args = argv[1:]
   if len(args) == 0 or not any(subcommand in args[0].upper() for subcommand in ["DEPLOY", "RENDER"]):
     args = ["deploy"] + args
 

--- a/schemachange/cli.py
+++ b/schemachange/cli.py
@@ -20,7 +20,7 @@ from cryptography.hazmat.primitives.asymmetric import dsa
 from cryptography.hazmat.primitives import serialization
 
 # Set a few global variables here
-_schemachange_version = '3.2.1'
+_schemachange_version = '3.2.2'
 _config_file_name = 'schemachange-config.yml'
 _metadata_database_name = 'METADATA'
 _metadata_schema_name = 'SCHEMACHANGE'

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ test_requires = parse_requirements("requirements.txt", session="schemachange")
 
 setup(
     name="schemachange",
-    version="3.2.1",
+    version="3.2.2",
     author="jamesweakley/jeremiahhansen",
     description="A Database Change Management tool for Snowflake",
     long_description=long_description,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,5 +1,4 @@
 import os
-import sys
 import pytest
 import unittest.mock as mock
 import schemachange.cli
@@ -52,10 +51,9 @@ DEFAULT_CONFIG = {
         {**DEFAULT_CONFIG, 'dry-run': True}),
 ])
 def test_main_deploy_subcommand_given_arguments_make_sure_arguments_set_on_call( args, expected):
-    sys.argv = args
 
     with mock.patch("schemachange.cli.deploy_command") as mock_deploy_command:
-        schemachange.cli.main()
+        schemachange.cli.main(args)
         mock_deploy_command.assert_called_once()
         [config,], _call_kwargs = mock_deploy_command.call_args
         assert config == expected
@@ -72,10 +70,9 @@ def test_main_deploy_subcommand_given_arguments_make_sure_arguments_set_on_call(
         ({**DEFAULT_CONFIG, 'verbose': True}, "script.sql")),
 ])
 def test_main_render_subcommand_given_arguments_make_sure_arguments_set_on_call( args, expected):
-    sys.argv = args
 
     with mock.patch("schemachange.cli.render_command") as mock_render_command:
-        schemachange.cli.main()
+        schemachange.cli.main(args)
         mock_render_command.assert_called_once()
         call_args, _call_kwargs = mock_render_command.call_args
         assert call_args == expected
@@ -97,10 +94,9 @@ def test_main_deploy_config_folder(args, to_mock, expected_args):
             '''))
 
         args[args.index("DUMMY")] = d
-        sys.argv = args
 
         with mock.patch(to_mock) as mock_command:
-            schemachange.cli.main()
+            schemachange.cli.main(args)
             mock_command.assert_called_once()
             call_args, _call_kwargs = mock_command.call_args
             assert call_args == expected_args
@@ -119,10 +115,9 @@ def test_main_deploy_modules_folder(args, to_mock, expected_args):
 
         args[args.index("DUMMY")] = d
         expected_args[0]['modules-folder'] = d
-        sys.argv = args
 
         with mock.patch(to_mock) as mock_command:
-            schemachange.cli.main()
+            schemachange.cli.main(args)
             mock_command.assert_called_once()
             call_args, _call_kwargs = mock_command.call_args
             assert call_args == expected_args

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,128 @@
+import os
+import sys
+import pytest
+import unittest.mock as mock
+import schemachange.cli
+import tempfile
+from textwrap import dedent
+
+DEFAULT_CONFIG = {
+    'root-folder': os.path.abspath('.'),
+    'modules-folder': None,
+    'snowflake-account': None,
+    'snowflake-user': None,
+    'snowflake-role':None,
+    'snowflake-warehouse': None,
+    'snowflake-database': None,
+    'change-history-table': None,
+    'vars': {},
+    'create-change-history-table': False,
+    'autocommit': False,
+    'verbose': False,
+    'dry-run': False,
+}
+
+
+@pytest.mark.parametrize("args, expected", [
+    (["schemachange"], DEFAULT_CONFIG),
+    (["schemachange", "deploy"], DEFAULT_CONFIG),
+    (["schemachange", "deploy", "-f", '.'],
+        {**DEFAULT_CONFIG, 'root-folder':os.path.abspath('.')}),
+    (["schemachange", "deploy", "--snowflake-account", "account"],
+        {**DEFAULT_CONFIG, 'snowflake-account': 'account'}),
+    (["schemachange", "deploy", "--snowflake-user", "user"],
+        {**DEFAULT_CONFIG, 'snowflake-user': 'user'}),
+    (["schemachange", "deploy", "--snowflake-role", "role"],
+        {**DEFAULT_CONFIG, 'snowflake-role': 'role'}),
+    (["schemachange", "deploy", "--snowflake-warehouse", "warehouse"],
+        {**DEFAULT_CONFIG, 'snowflake-warehouse': 'warehouse'}),
+    (["schemachange", "deploy", "--snowflake-database", "database"],
+        {**DEFAULT_CONFIG, 'snowflake-database': 'database'}),
+    (["schemachange", "deploy", "--change-history-table", "db.schema.table"],
+        {**DEFAULT_CONFIG, 'change-history-table': 'db.schema.table'}),
+    (["schemachange", "deploy", "--vars", '{"var1": "val"}'],
+        {**DEFAULT_CONFIG, 'vars': {'var1' : 'val'},}),
+    (["schemachange", "deploy", "--create-change-history-table"],
+        {**DEFAULT_CONFIG, 'create-change-history-table': True}),
+    (["schemachange", "deploy", "--autocommit"],
+        {**DEFAULT_CONFIG, 'autocommit': True}),
+    (["schemachange", "deploy", "--verbose"],
+        {**DEFAULT_CONFIG, 'verbose': True}),
+    (["schemachange", "deploy", "--dry-run"],
+        {**DEFAULT_CONFIG, 'dry-run': True}),
+])
+def test_main_deploy_subcommand_given_arguments_make_sure_arguments_set_on_call( args, expected):
+    sys.argv = args
+
+    with mock.patch("schemachange.cli.deploy_command") as mock_deploy_command:
+        schemachange.cli.main()
+        mock_deploy_command.assert_called_once()
+        [config,], _call_kwargs = mock_deploy_command.call_args
+        assert config == expected
+
+
+@pytest.mark.parametrize("args, expected", [
+    (["schemachange", "render", "script.sql"],
+        ({**DEFAULT_CONFIG}, "script.sql")),
+    (["schemachange", "render", "--root-folder", '.', "script.sql"],
+        ({**DEFAULT_CONFIG, 'root-folder': os.path.abspath('.')}, "script.sql")),
+    (["schemachange", "render", "--vars", '{"var1": "val"}', "script.sql"],
+        ({**DEFAULT_CONFIG, 'vars': {"var1": "val"}}, "script.sql")),
+    (["schemachange", "render", "--verbose", "script.sql"],
+        ({**DEFAULT_CONFIG, 'verbose': True}, "script.sql")),
+])
+def test_main_render_subcommand_given_arguments_make_sure_arguments_set_on_call( args, expected):
+    sys.argv = args
+
+    with mock.patch("schemachange.cli.render_command") as mock_render_command:
+        schemachange.cli.main()
+        mock_render_command.assert_called_once()
+        call_args, _call_kwargs = mock_render_command.call_args
+        assert call_args == expected
+
+
+@pytest.mark.parametrize("args, to_mock, expected_args", [
+    (["schemachange", "deploy", "--config-folder", "DUMMY"],
+        "schemachange.cli.deploy_command",
+        ({**DEFAULT_CONFIG, 'snowflake-account': 'account'},)),
+    (["schemachange", "render", "script.sql", "--config-folder", "DUMMY"],
+        "schemachange.cli.render_command",
+        ({**DEFAULT_CONFIG, 'snowflake-account': 'account'}, "script.sql"))
+])
+def test_main_deploy_config_folder(args, to_mock, expected_args):
+    with tempfile.TemporaryDirectory() as d:
+        with open(os.path.join(d, 'schemachange-config.yml'), 'wt') as f:
+            f.write(dedent('''
+                snowflake-account: account
+            '''))
+
+        args[args.index("DUMMY")] = d
+        sys.argv = args
+
+        with mock.patch(to_mock) as mock_command:
+            schemachange.cli.main()
+            mock_command.assert_called_once()
+            call_args, _call_kwargs = mock_command.call_args
+            assert call_args == expected_args
+
+
+@pytest.mark.parametrize("args, to_mock, expected_args", [
+    (["schemachange", "deploy", "--modules-folder", "DUMMY"],
+        "schemachange.cli.deploy_command",
+        ({**DEFAULT_CONFIG, 'modules-folder': 'DUMMY'},)),
+    (["schemachange", "render", "script.sql", "--modules-folder", "DUMMY"],
+        "schemachange.cli.render_command",
+        ({**DEFAULT_CONFIG, 'modules-folder': 'DUMMY'}, "script.sql"))
+])
+def test_main_deploy_modules_folder(args, to_mock, expected_args):
+    with tempfile.TemporaryDirectory() as d:
+
+        args[args.index("DUMMY")] = d
+        expected_args[0]['modules-folder'] = d
+        sys.argv = args
+
+        with mock.patch(to_mock) as mock_command:
+            schemachange.cli.main()
+            mock_command.assert_called_once()
+            call_args, _call_kwargs = mock_command.call_args
+            assert call_args == expected_args


### PR DESCRIPTION
This is a small change with a couple of benefits -

main one is you can invoke schemachange in a python script by invoking schemachange.main(['schemachange', 'deploy', ...]), which is useful.

secondary is it makes the tests a bit nicer :) I've based this on tests pr to show (and test) this, the commit to look at is the top one, aa9b503733399fd67f3f0d28437f4fe5aba752d4