### PR TITLE
Add Jinja filter for using environmental variables in templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 *The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).*
 
+## [3.3.0] - TBD
+### Added
+- Jinja filter for extracting variables from the environment
+
 ## [3.2.0] - 2021-10-28
 ### Added
 - Added support for jinja templates. Any file ending .sql or .sql.jinja will be processed using the [Jinja engine](https://jinja.palletsprojects.com/)

--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ schemachange supports the jinja engine for a variable replacement strategy. One 
 
 To pass variables to schemachange, check out the [Configuration](#configuration) section below. You can either use the `--vars` command line parameter or the YAML config file `schemachange-config.yml`. For the command line version you can pass variables like this: `--vars '{"variable1": "value", "variable2": "value2"}'`. This parameter accepts a flat JSON object formatted as a string. Nested objects and arrays don't make sense at this point and aren't supported.
 
+Variables can also be extracted directly from the environment by using the `from_environ` Jinja custom filter. Environmental variables should be specified in the following form: `{{ variable | from_environ(<ENVIRONMENTAL_VARIABLE>) }}`. If `<ENVIRONMENTAL_VARIABLE>` is not found, the default `variable` is used. This default can either be provided as a string, or passed in used the `--vars` command line parameter. This approach is useful for adding secrets, such as access/secret keys for external stages.
+
 schemachange will replace any variable placeholders before running your change script code and will throw an error if it finds any variable placeholders that haven't been replaced.
 
 ### Jinja templating engine

--- a/demo/citibike_jinja_env/V1.1__initial_database_objects.sql
+++ b/demo/citibike_jinja_env/V1.1__initial_database_objects.sql
@@ -1,0 +1,67 @@
+-- Create the database if it doesn't exist
+CREATE DATABASE IF NOT EXISTS SCHEMACHANGE_DEMO;
+
+-- Set the database and schema context
+USE SCHEMA SCHEMACHANGE_DEMO.PUBLIC;
+
+-- Create the file formats
+CREATE OR REPLACE FILE FORMAT CSV_NO_HEADER
+    TYPE='CSV'
+    COMPRESSION = 'AUTO'
+    FIELD_DELIMITER = ','
+    SKIP_HEADER = 0
+    FIELD_OPTIONALLY_ENCLOSED_BY = '"'
+    NULL_IF = ('NULL','\\N','\N', '');
+
+CREATE OR REPLACE FILE FORMAT JSON
+    TYPE='JSON'
+    COMPRESSION = 'AUTO'
+    ENABLE_OCTAL = FALSE
+    ALLOW_DUPLICATE = FALSE
+    STRIP_OUTER_ARRAY = FALSE
+    STRIP_NULL_VALUES = FALSE
+    IGNORE_UTF8_ERRORS = FALSE;
+
+-- Create the stages
+
+-- Stages located in S3 require AWS_KEY_ID and AWS_SECRET_KEY
+-- to be specified (if no STORAGE INTEGRATION exists)
+-- If these are specified in `--vars` they will be printed to stdout,
+-- so we want to get these directly from environment.
+-- If not found in environment, falls back to checking vars.
+CREATE OR REPLACE STAGE TRIPS
+    URL = 's3://snowflake-workshop-lab/citibike-trips'
+    CREDENTIALS = (
+        AWS_KEY_ID = '{{ aws_s3_access_key | from_environ("AWS_S3_ACCESS_KEY") }}',
+        AWS_SECRET_KEY = '{{ aws_s3_secret_key | from_environ("AWS_S3_ACCESS_KEY") }}'
+    );
+
+CREATE OR REPLACE STAGE WEATHER
+    URL = 's3://snowflake-workshop-lab/weather-nyc';
+
+-- Create the tables
+CREATE OR REPLACE TABLE TRIPS
+(
+     TRIPDURATION INTEGER
+    ,STARTTIME TIMESTAMP
+    ,STOPTIME TIMESTAMP
+    ,START_STATION_ID INTEGER
+    ,START_STATION_NAME STRING
+    ,START_STATION_LATITUDE FLOAT
+    ,START_STATION_LONGITUDE FLOAT
+    ,END_STATION_ID INTEGER
+    ,END_STATION_NAME STRING
+    ,END_STATION_LATITUDE FLOAT
+    ,END_STATION_LONGITUDE FLOAT
+    ,BIKEID INTEGER
+    ,MEMBERSHIP_TYPE STRING
+    ,USERTYPE STRING
+    ,BIRTH_YEAR INTEGER
+    ,GENDER INTEGER
+);
+
+CREATE OR REPLACE TABLE WEATHER
+(
+     V VARIANT
+    ,T TIMESTAMP
+);

--- a/demo/citibike_jinja_env/V1.2__load_tables_from_s3.sql
+++ b/demo/citibike_jinja_env/V1.2__load_tables_from_s3.sql
@@ -1,0 +1,16 @@
+-- Set the database and schema context
+USE SCHEMA SCHEMACHANGE_DEMO.PUBLIC;
+
+-- Load the trips data
+COPY INTO TRIPS FROM @TRIPS
+    FILE_FORMAT = (FORMAT_NAME = 'CSV_NO_HEADER');
+
+-- Load the weather data
+COPY INTO WEATHER FROM
+    (
+        SELECT
+             $1
+            ,CONVERT_TIMEZONE('UTC', 'US/Eastern', $1:time::TIMESTAMP_NTZ)
+        FROM @WEATHER
+    )
+    FILE_FORMAT = (FORMAT_NAME = 'JSON');

--- a/schemachange/cli.py
+++ b/schemachange/cli.py
@@ -19,7 +19,7 @@ from cryptography.hazmat.primitives.asymmetric import dsa
 from cryptography.hazmat.primitives import serialization
 
 # Set a few global variables here
-_schemachange_version = '3.2.0'
+_schemachange_version = '3.3.0'
 _config_file_name = 'schemachange-config.yml'
 _metadata_database_name = 'METADATA'
 _metadata_schema_name = 'SCHEMACHANGE'
@@ -40,11 +40,16 @@ class JinjaTemplateProcessor:
       loader = jinja2.FileSystemLoader(project_root)
 
     self.__environment = jinja2.Environment(loader=loader, undefined=jinja2.StrictUndefined)
+    self.add_filter("from_environ", from_environ)
     self.__project_root = project_root
 
   def override_loader(self, loader: jinja2.BaseLoader):
     # to make unit testing easier
     self.__environment = jinja2.Environment(loader=loader, undefined=jinja2.StrictUndefined)
+    self.add_filter("from_environ", from_environ)
+
+  def add_filter(self, filter_name, filter_func):
+    self.__environment.filters[filter_name] = filter_func
 
   def render(self, script: str, vars: Dict[str, Any], verbose: bool) -> str:
     if not vars:
@@ -58,6 +63,11 @@ class JinjaTemplateProcessor:
 
   def relpath(self, file_path: str):
     return os.path.relpath(file_path, self.__project_root)
+
+
+def from_environ(value, variable):
+  """Tries to get environmental variable, reverts to specified value if not found."""
+  return os.getenv(variable, value)
 
 
 def deploy_command(config):

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ test_requires = parse_requirements("requirements.txt", session="schemachange")
 
 setup(
     name="schemachange",
-    version="3.2.0",
+    version="3.3.0",
     author="jamesweakley/jeremiahhansen",
     description="A Database Change Management tool for Snowflake",
     long_description=long_description,

--- a/tests/test_jinja_from_environ_filter.py
+++ b/tests/test_jinja_from_environ_filter.py
@@ -1,0 +1,64 @@
+import json
+import os
+
+import pytest
+from jinja2 import DictLoader
+from jinja2.exceptions import UndefinedError
+from schemachange.cli import JinjaTemplateProcessor
+
+
+def test_from_environ_not_set():
+    processor = JinjaTemplateProcessor("", None)
+
+    # overide the default loader
+    templates = {"test.sql": "some text {{ myvar | from_environ('MYVAR') }}"}
+    processor.override_loader(DictLoader(templates))
+
+    with pytest.raises(UndefinedError) as e:
+        context = processor.render("test.sql", None, True)
+
+    assert str(e.value) == "'myvar' is undefined"
+
+
+def test_from_environ_set():
+    processor = JinjaTemplateProcessor("", None)
+
+    # set MYVAR env variable
+    os.environ["MYVAR"] = "myvar_from_environment"
+
+    # overide the default loader
+    templates = {"test.sql": "some text {{ myvar | from_environ('MYVAR') }}"}
+    processor.override_loader(DictLoader(templates))
+
+    context = processor.render("test.sql", None, True)
+
+    # unset MYVAR env variable
+    del os.environ["MYVAR"]
+
+    assert context == "some text myvar_from_environment"
+
+
+def test_from_environ_not_set_default():
+    processor = JinjaTemplateProcessor("", None)
+
+    # overide the default loader
+    templates = {"test.sql": "some text {{ 'myvar_default' | from_environ('MYVAR') }}"}
+    processor.override_loader(DictLoader(templates))
+
+    context = processor.render("test.sql", None, True)
+
+    assert context == "some text myvar_default"
+
+
+def test_from_environ_not_set_vars():
+    processor = JinjaTemplateProcessor("", None)
+
+    # overide the default loader
+    templates = {"test.sql": "some text {{ myvar | from_environ('MYVAR') }}"}
+    processor.override_loader(DictLoader(templates))
+
+    vars = json.loads('{"myvar" : "myvar_from_vars"}')
+
+    context = processor.render("test.sql", vars, True)
+
+    assert context == "some text myvar_from_vars"


### PR DESCRIPTION
Adding a Jinja custom filter that allows using environmental variables in templates. This is very useful for passing in secrets for external stages without logging them to STDOUT, like it is done for command line parameters.