### PR TITLE
3.3.0: Adding dynamic support to config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 *The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).*
 
 
+## [3.3.0] - TBD
+### Added
+- Added processing of schemachange-config.yml with jinja templating engine.
+  - Included new Jinja function env_var for accessing environmental variables from the config file.
+
 ## [3.2.1] - 2021-11-04
 ### Fixed
 - Jinja Template Engine was not recognising scripts in subfolders on windows machines. Jinja was expecting the paths to follow a unix style ie SQL/V2.0.0__ADHOC_SCRIPT.sql but on windows machines this was being passed through as SQL\V2.0.0__ADHOC_SCRIPT.sql.

--- a/README.md
+++ b/README.md
@@ -255,6 +255,22 @@ dry-run: false
 
 ```
 
+#### Yaml Jinja support
+The YAML config file supports the jinja templating language and has a custom function "env_var" to access environmental variables.
+
+##### env_var
+Provides access to environmental variables. The function can be used two different ways.
+
+Return the value of the environmental variable if it exists, otherwise return the default value.
+``` jinja
+{{ env_var('<environmental_variable>', 'default') }}
+```
+
+Return the value of the environmental variable if it exists, otherwise raise an error.
+``` jinja
+{{ env_var('<environmental_variable>') }}
+```
+
 ### Command Line Arguments
 
 Schemachange supports a number of subcommands, it the subcommand is not provided it is defaulted to deploy. This behaviour keeps compatibility with versions prior to 3.2.

--- a/demo/citibike_jinja/schemachange-config.yml
+++ b/demo/citibike_jinja/schemachange-config.yml
@@ -3,4 +3,4 @@ config-version: 1
 root-folder: scripts
 modules-folder: modules
 vars: 
-  database_name: SCHEMACHANGE_DEMO_JINJA     
+  database_name: {{env_var('SF_DATABASE', 'SCHEMACHANGE_DEMO_JINJA')}}     

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ test_requires = parse_requirements("requirements.txt", session="schemachange")
 
 setup(
     name="schemachange",
-    version="3.2.1",
+    version="3.3.0",
     author="jamesweakley/jeremiahhansen",
     description="A Database Change Management tool for Snowflake",
     long_description=long_description,

--- a/tests/test_JinjaEnvVar.py
+++ b/tests/test_JinjaEnvVar.py
@@ -6,29 +6,34 @@ import unittest.mock as mock
 from schemachange.cli import JinjaEnvVar
 
 
-@mock.patch.dict(os.environ, {})
+@mock.patch.dict(os.environ, {}, clear=True)
 def test_env_var_with_no_default_and_no_environmental_variables_should_raise_exception():
+
+    assert ('SF_DATABASE' in os.environ) is False
 
     with pytest.raises(ValueError) as e:
       result = JinjaEnvVar.env_var('SF_DATABASE')
     assert str(e.value) == "Could not find environmental variable SF_DATABASE and no default value was provided"
 
 
-@mock.patch.dict(os.environ, {})
+@mock.patch.dict(os.environ, {}, clear=True)
 def test_env_var_with_default_and_no_environmental_variables_should_return_default():
    
+    print(os.environ)
+    assert ('SF_DATABASE' in os.environ) is False
+
     result = JinjaEnvVar.env_var('SF_DATABASE', 'SCHEMACHANGE_DEMO')
     assert result == 'SCHEMACHANGE_DEMO'
 
 
-@mock.patch.dict(os.environ, {"SF_DATABASE": "SCHEMACHANGE_DEMO_2"})
+@mock.patch.dict(os.environ, {"SF_DATABASE": "SCHEMACHANGE_DEMO_2"}, clear=True)
 def test_env_var_with_default_and_environmental_variables_should_return_environmental_variable_value():
    
     result = JinjaEnvVar.env_var('SF_DATABASE', 'SCHEMACHANGE_DEMO')
     assert result == 'SCHEMACHANGE_DEMO_2'
 
 
-@mock.patch.dict(os.environ, {"SF_DATABASE": "SCHEMACHANGE_DEMO_3"})
+@mock.patch.dict(os.environ, {"SF_DATABASE": "SCHEMACHANGE_DEMO_3"}, clear=True)
 def test_JinjaEnvVar_with_jinja_template():
     
     template = jinja2.Template("{{env_var('SF_DATABASE', 'SCHEMACHANGE_DEMO')}}", extensions=[JinjaEnvVar])

--- a/tests/test_JinjaEnvVar.py
+++ b/tests/test_JinjaEnvVar.py
@@ -1,0 +1,35 @@
+import os
+import jinja2
+import pytest
+import unittest.mock as mock
+
+from schemachange.cli import JinjaEnvVar
+
+
+@mock.patch.dict(os.environ, {})
+def test_env_var_with_no_default_and_no_environmental_variables_should_raise_exception():
+
+    with pytest.raises(ValueError) as e:
+      result = JinjaEnvVar.env_var('SF_DATABASE')
+    assert str(e.value) == "Could not find environmental variable SF_DATABASE and no default value was provided"
+
+
+@mock.patch.dict(os.environ, {})
+def test_env_var_with_default_and_no_environmental_variables_should_return_default():
+   
+    result = JinjaEnvVar.env_var('SF_DATABASE', 'SCHEMACHANGE_DEMO')
+    assert result == 'SCHEMACHANGE_DEMO'
+
+
+@mock.patch.dict(os.environ, {"SF_DATABASE": "SCHEMACHANGE_DEMO_2"})
+def test_env_var_with_default_and_environmental_variables_should_return_environmental_variable_value():
+   
+    result = JinjaEnvVar.env_var('SF_DATABASE', 'SCHEMACHANGE_DEMO')
+    assert result == 'SCHEMACHANGE_DEMO_2'
+
+
+@mock.patch.dict(os.environ, {"SF_DATABASE": "SCHEMACHANGE_DEMO_3"})
+def test_JinjaEnvVar_with_jinja_template():
+    
+    template = jinja2.Template("{{env_var('SF_DATABASE', 'SCHEMACHANGE_DEMO')}}", extensions=[JinjaEnvVar])
+    assert template.render() == "SCHEMACHANGE_DEMO_3"

--- a/tests/test_load_schemachange_config.py
+++ b/tests/test_load_schemachange_config.py
@@ -1,0 +1,63 @@
+import os
+import pathlib
+import pytest
+import unittest.mock as mock
+
+from schemachange.cli import load_schemachange_config
+
+
+def test__load_schemachange_config__simple_config_file(tmp_path: pathlib.Path):
+
+    config_contents = """
+config-version: 1
+root-folder: scripts
+modules-folder: modules
+vars: 
+  database_name: SCHEMACHANGE_DEMO_JINJA   
+"""
+    config_file = tmp_path / "schemachange-config.yml"
+    config_file.write_text(config_contents)
+    
+
+    config = load_schemachange_config(str(config_file))
+
+    assert config['config-version'] == 1
+    assert config['root-folder'] == 'scripts'
+    assert config['modules-folder'] == 'modules'
+    assert config['vars']['database_name'] == 'SCHEMACHANGE_DEMO_JINJA'
+
+
+@mock.patch.dict(os.environ, {"TEST_VAR": "env_value"})
+def test__load_schemachange_config__with_env_var_should_populate_value(tmp_path: pathlib.Path):
+
+    config_contents = """
+config-version: 1.1
+root-folder: {{env_var('TEST_VAR')}}
+modules-folder: modules
+vars: 
+  database_name: SCHEMACHANGE_DEMO_JINJA   
+"""
+    config_file = tmp_path / "schemachange-config.yml"
+    config_file.write_text(config_contents)
+
+    config = load_schemachange_config(str(config_file))
+    
+    assert config['root-folder'] == 'env_value'    
+
+
+def test__load_schemachange_config__requiring_env_var_but_env_var_not_set_should_raise_exception(tmp_path: pathlib.Path):
+
+    config_contents = """
+config-version: 1.1
+root-folder: {{env_var('TEST_VAR')}}
+modules-folder: modules
+vars: 
+  database_name: SCHEMACHANGE_DEMO_JINJA   
+"""
+    config_file = tmp_path / "schemachange-config.yml"
+    config_file.write_text(config_contents)
+    
+    with pytest.raises(ValueError) as e:
+      config = load_schemachange_config(str(config_file))            
+    assert str(e.value) == "Could not find environmental variable TEST_VAR and no default value was provided"
+


### PR DESCRIPTION
# Description
Extending Jinja templating support to schemachange-config.yml, plus a custom function to allow access to environmental variables. I believe this would satisfy #84.

A command line like the following
```
schemachange -f MORE2/ -a ${SF_ACCOUNT} -u ${SF_USERNAME} -r ${SF_ROLE} -w ${SF_WAREHOUSE} -d ${SF_DATABASE} -c ${SF_DATABASE}.SCHEMACHANGE.CHANGE_HISTORY --create-change-history-table 
```

could use the following schemachange-config.yml file
``` yaml
config-version: 1
root-folder: MORE2/
snowflake-account: {{env_var("SF_ACCOUNT")}}
snowflake-user: {{env_var("SF_USERNAME")}}
snowflake-role: {{env_var("SF_ROLE")}}
snowflake-warehouse: {{env_var("SF_WAREHOUSE")}}
snowflake-database: {{env_var("SF_DATABASE")}}
change-history-table: {{env_var("SF_DATABASE")}}.SCHEMACHANGE.CHANGE_HISTORY 
create-change-history-table: true
```

Since it is using the jinja template engine additional logic can also be added to vary values based on an environmental variable. The following is an example of varying the config value based on some custom logic.

``` yaml
config-version: 1
snowflake-account: {{"prod_account" if env_var("SF_ENVIRONMENT") == "PROD" else "dev_account"}}
snowflake-user: {{"PROD_USER" if env_var("SF_ENVIRONMENT") == "PROD" else "DEV_USER"}}
```

# Conflicts
This pull request does not include the ability for script files to access environmental variables, just the config file. However, I need to call out a conflict with #90, since it provides a different approach for accessing environmental variables. One exposes a custom filter and the other a custom function. We should make sure only one approach is used.

I feel the functionality provided by 'env_var' function has the edge, it allows:
1. a default value to be used if the environmental variable is not available
2. an error to be raised if the environmental variable is not available

while 'from_environ' only support the first scenario. 

If we aligned the approach used in #90 to use 'env_var' function

```
CREATE OR REPLACE STAGE TRIPS
    URL = 's3://snowflake-workshop-lab/citibike-trips'
    CREDENTIALS = (
        AWS_KEY_ID = '{{ aws_s3_access_key | from_environ("AWS_S3_ACCESS_KEY") }}',
        AWS_SECRET_KEY = '{{ aws_s3_secret_key | from_environ("AWS_S3_ACCESS_KEY") }}'
    );
````
would be rewritten as follows. 
```
CREATE OR REPLACE STAGE TRIPS
    URL = 's3://snowflake-workshop-lab/citibike-trips'
    CREDENTIALS = (
        AWS_KEY_ID = '{{ env_var("AWS_S3_ACCESS_KEY", aws_s3_access_key) }}',
        AWS_SECRET_KEY = '{{ env_var("AWS_S3_SECRET_KEY", aws_s3_secret_key) }}',
    );
```
If you wanted it to fail if the environmental variable does not exist it would be like 
```
CREATE OR REPLACE STAGE TRIPS
    URL = 's3://snowflake-workshop-lab/citibike-trips'
    CREDENTIALS = (
        AWS_KEY_ID = '{{ env_var("AWS_S3_ACCESS_KEY") }}',
        AWS_SECRET_KEY = '{{ env_var("AWS_S3_SECRET_KEY") }}',
    );

```

@sfc-gh-jhansen  let me know your thoughts on the style you would like for the jinja template to access environmental variables.

# Other considerations
Would we want to bundle this with #89 and move to 3.3.0 and one release to PYPI? 


