### PR TITLE
Update fetch_r_script_checksum to iterate over multiple results batches within a cursor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 *The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).*
 
+## [3.4.2] - 2022-06-14
+### Fixed
+- Updated fetch_r_script_checksum method in the CLI to iterate over multiple results batches within a single cursor. This protects against failure in the case where the R-script results are large enough to require multiple batches. Ref snowflake-python-connector documentation here: https://docs.snowflake.com/en/user-guide/python-connector-api.html#get_result_batches
+
 ## [3.4.1] - 2021-12-08
 ### Added
 - Added a new optional parameter `--query-tag` to append a string to the QUERY_TAG that is attached to every SQL statement executed

--- a/schemachange/cli.py
+++ b/schemachange/cli.py
@@ -22,7 +22,7 @@ from cryptography.hazmat.primitives.asymmetric import dsa
 from cryptography.hazmat.primitives import serialization
 
 # Set a few global variables here
-_schemachange_version = '3.4.1'
+_schemachange_version = '3.4.2'
 _config_file_name = 'schemachange-config.yml'
 _metadata_database_name = 'METADATA'
 _metadata_schema_name = 'SCHEMACHANGE'
@@ -614,9 +614,11 @@ def fetch_r_scripts_checksum(change_history_table, snowflake_session_parameters,
   script_names = []
   checksums = []
   for cursor in results:
-    for row in cursor:
-      script_names.append(row[0])
-      checksums.append(row[1])
+    batches = cursor.get_result_batches()
+    for batch in batches:
+      for row in batch:
+        script_names.append(row[0])
+        checksums.append(row[1])
 
   d_script_checksum['script_name'] = script_names
   d_script_checksum['checksum'] = checksums

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = schemachange
-version = 3.4.1
+version = 3.4.2
 author = jamesweakley/jeremiahhansen
 description = A Database Change Management tool for Snowflake
 long_description = file: README.md
@@ -20,6 +20,7 @@ install_requires =
     pandas~=1.3
     pyyaml~=5.4
     jinja2~=3.0
+    pyarrow>=6.0.0,<6.1.0
 include_package_data = True
 
 [options.entry_points]


### PR DESCRIPTION
In our experience using schemachange, we have run into an issue where fetch_r_script_checksum fails due to the quantity of R-scripts in our pipeline exceeding the data size that will fit within one Result Batch as returned by snowflake-connector-python.  It will successfully iterate over all the rows in the first "chunk" but fail to proceed into a second chunk if it exists.  The suggested code update resolves this by first returning all results batches and iterating through the rows within each batch.  It does require pyarrow to be installed, which I've added to setup.cfg.  The specified range of versions matches those required by snowflake-connector-python.

Note that I did discover the latest version of snowflake-connector-python (2.7.8) _no longer fails_ with the existing fetch_r_script_checksum code as-written, so upgrading that config requirement may also work.  That said I tested the suggested code update below with snowflake-connector-python 2.6.2, 2.7.4, and 2.7.8 and it works on all of them, so it would be more flexible and could be implemented without upgrading to 2.7.8 yet.