### PR TITLE
PEP8 Sorted Imports

### DIFF
--- a/schemachange/cli.py
+++ b/schemachange/cli.py
@@ -1,25 +1,25 @@
-import os
-import string
-import re
 import argparse
+import hashlib
+import json
+import os
+import pathlib
+import re
+import string
+import sys
+import textwrap
+import time
+import warnings
+from typing import Any, Dict, Optional, Set, Type
+
 import jinja2
 import jinja2.ext
-import json
-import time
-import hashlib
-from jinja2.loaders import BaseLoader
 import snowflake.connector
-import sys
-import warnings
-import textwrap
 import yaml
-from typing import Dict, Any, Optional, Set, Type
-from pandas import DataFrame
-import pathlib
 from cryptography.hazmat.backends import default_backend
-from cryptography.hazmat.primitives.asymmetric import rsa
-from cryptography.hazmat.primitives.asymmetric import dsa
 from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import dsa, rsa
+from jinja2.loaders import BaseLoader
+from pandas import DataFrame
 
 # Set a few global variables here
 _schemachange_version = '3.4.1'

--- a/tests/test_JinjaEnvVar.py
+++ b/tests/test_JinjaEnvVar.py
@@ -1,7 +1,8 @@
 import os
+import unittest.mock as mock
+
 import jinja2
 import pytest
-import unittest.mock as mock
 
 from schemachange.cli import JinjaEnvVar
 

--- a/tests/test_JinjaTemplateProcessor.py
+++ b/tests/test_JinjaTemplateProcessor.py
@@ -1,8 +1,10 @@
 import json
 import pathlib
+
 import pytest
-from jinja2 import Environment, DictLoader
+from jinja2 import DictLoader, Environment
 from jinja2.exceptions import UndefinedError
+
 from schemachange.cli import JinjaTemplateProcessor
 
 

--- a/tests/test_SecretManager.py
+++ b/tests/test_SecretManager.py
@@ -1,5 +1,6 @@
 from schemachange.cli import SecretManager
 
+
 ##### test Class #####
 def test_SecretManager_given_no_secrets_when_redact_then_return_original_value():
     sm = SecretManager()

--- a/tests/test_extract_config_secrets.py
+++ b/tests/test_extract_config_secrets.py
@@ -1,5 +1,7 @@
 import pytest
+
 from schemachange.cli import extract_config_secrets
+
 
 def test_extract_config_secrets_given_empty_config_should_not_error():
     config = {}

--- a/tests/test_get_all_scripts_recursively.py
+++ b/tests/test_get_all_scripts_recursively.py
@@ -1,6 +1,8 @@
 import os
-import pytest
 import unittest.mock as mock
+
+import pytest
+
 from schemachange.cli import get_all_scripts_recursively
 
 #######################

--- a/tests/test_jinja_env_var_template.py
+++ b/tests/test_jinja_env_var_template.py
@@ -3,6 +3,7 @@ import os
 
 import pytest
 from jinja2 import DictLoader
+
 from schemachange.cli import JinjaTemplateProcessor
 
 

--- a/tests/test_load_schemachange_config.py
+++ b/tests/test_load_schemachange_config.py
@@ -1,7 +1,8 @@
 import os
 import pathlib
-import pytest
 import unittest.mock as mock
+
+import pytest
 
 from schemachange.cli import load_schemachange_config
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,9 +1,11 @@
 import os
-import pytest
-import unittest.mock as mock
-import schemachange.cli
 import tempfile
+import unittest.mock as mock
 from textwrap import dedent
+
+import pytest
+
+import schemachange.cli
 
 DEFAULT_CONFIG = {
     'root-folder': os.path.abspath('.'),


### PR DESCRIPTION
Sorted the imports as in PEP8 standard.  https://peps.python.org/pep-0008/#imports

This makes the import lists a little easier to follow - and its the standard some people are used to.

I used the `isort` config but I didn't include the `.isort.cfg` because people might not want to use that one going forward. 

