### PR TITLE
Reset the session before logging

### DIFF
--- a/schemachange/cli.py
+++ b/schemachange/cli.py
@@ -436,6 +436,8 @@ class SnowflakeSchemachangeSession:
       self.reset_query_tag()
       end = time.time()
       execution_time = round(end - start)
+      # reset the session before logging
+      self.reset_session()
 
 
     # Finally record this change in the change history table by gathering data


### PR DESCRIPTION
Issue #161 The session needs to be reset in case role, database, or warehouse were set within the migration script.