### PR TITLE
Added tox configuration and updating dependency reqs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,6 @@ dmypy.json
 
 # Mac files
 **/.DS_Store
+
+# Ruff Cache
+.ruff_cache

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Jinja2==3.0.0
 pandas==1.3.0
 PyYAML==5.4
-snowflake-connector-python==2.8.0
+snowflake-connector-python>=2.8.0,<=3.0.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,13 +10,14 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Operating System :: OS Independent
 
 [options]
 packages = schemachange
 python_requires = >=3.7
 install_requires =
-    snowflake-connector-python~=2.8
+    snowflake-connector-python>=2.8.0,<=3.0.2
     pandas~=1.3
     pyyaml~=5.4
     jinja2~=3.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,11 @@
+[tox]
+requires =
+    tox>=4
+env_list = lint, type, py{37,38,39,310}
+
+[testenv]
+description = run pytest
+deps =
+    pytest
+commands =
+    pytest {posargs:tests}


### PR DESCRIPTION
Updating requirements and adding tox. 

The current repo is using a Dockerfile to test Python 3.9 compatibility. I'm proposing using [tox](https://tox.wiki/en/latest/) to automatically execute tests across different versions of Python. 

There have been some inconsistencies recently with the cryptography and pyOpenSSL libraries between versions and I'm hoping this will ensure we can safely test the package installs and unit tests on each version of Python that schemachange supports.

Closes #165  