### PR TITLE
fix: role name can include special characters such as hyphens - issue…

### DIFF
--- a/schemachange/cli.py
+++ b/schemachange/cli.py
@@ -210,7 +210,7 @@ class SnowflakeSchemachangeSession:
     + "CHECKSUM, EXECUTION_TIME, STATUS, INSTALLED_BY, INSTALLED_ON) values ('{script_version}'," \
     + "'{script_description}','{script_name}','{script_type}','{checksum}',{execution_time}," \
     + "'{status}','{user}',CURRENT_TIMESTAMP);"
-  _q_set_sess_role = 'USE ROLE {role};'
+  _q_set_sess_role = 'USE ROLE "{role}";'
   _q_set_sess_database = 'USE DATABASE {database};'
   _q_set_sess_schema = 'USE SCHEMA {schema};'
   _q_set_sess_warehouse = 'USE WAREHOUSE {warehouse};'


### PR DESCRIPTION
… #215
This bug was introduced after refactoring of Schemachange in v3.5
Whenever schemachange role contains "-" execution breaks:

snowflake.connector.errors.ProgrammingError: 001003 (42000): SQL compilation error:
syntax error line 1 at position 13 unexpected '-'.
Error: Process completed with exit code 1.

