### PR TITLE
Add in repeatable migration batching process

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,517 +1,1018 @@
-# schemachange
-<img src="images/schemachange-logo-title.png" alt="schemachange" title="schemachange logo" width="600" />
-
-*Looking for snowchange? You've found the right spot. snowchange has been renamed to schemachange.*
-
-[![pytest](https://github.com/Snowflake-Labs/schemachange/actions/workflows/pytest.yml/badge.svg)](https://github.com/Snowflake-Labs/schemachange/actions/workflows/pytest.yml)
-[![PyPI](https://img.shields.io/pypi/v/schemachange.svg)](https://pypi.org/project/schemachange)
-## Overview
-
-schemachange is a simple python based tool to manage all of your [Snowflake](https://www.snowflake.com/) objects. It follows an Imperative-style approach to Database Change Management (DCM) and was inspired by the [Flyway database migration tool](https://flywaydb.org). When combined with a version control system and a CI/CD tool, database changes can be approved and deployed through a pipeline using modern software delivery practices. As such schemachange plays a critical role in enabling Database (or Data) DevOps.
-
-DCM tools (also known as Database Migration, Schema Change Management, or Schema Migration tools) follow one of two approaches: Declarative or Imperative. For a background on Database DevOps, including a discussion on the differences between the Declarative and Imperative approaches, please read the [Embracing Agile Software Delivery and DevOps with Snowflake](https://www.snowflake.com/blog/embracing-agile-software-delivery-and-devops-with-snowflake/) blog post.
-
-For the complete list of changes made to schemachange check out the [CHANGELOG](CHANGELOG.md).
-
-**Please note** that schemachange is a community-developed tool, not an official Snowflake offering. It comes with no support or warranty.
-
-## Table of Contents
-
-1. [Overview](#overview)
-1. [Project Structure](#project-structure)
-   1. [Folder Structure](#folder-structure)
-1. [Change Scripts](#change-scripts)
-   1. [Versioned Script Naming](#versioned-script-naming)
-   1. [Repeatable Script Naming](#repeatable-script-naming)
-   1. [Always Script Naming](#always-script-naming)
-   1. [Script Requirements](#script-requirements)
-   1. [Using Variables in Scripts](#using-variables-in-scripts)
-      1. [Secrets filtering](#secrets-filtering)
-   1. [Jinja templating engine](#jinja-templating-engine)
-   1. [Gotchas](#gotchas)
-1. [Change History Table](#change-history-table)
-1. [Authentication](#authentication)
-   1. [Password Authentication](#password-authentication)
-   1. [Private Key Authentication](#private-key-authentication)
-   1. [Oauth Authentication](#oauth-authentication)
-   1. [External Browser Authentication](#external-browser-authentication)
-   1. [Okta Authentication](#okta-authentication)
-1. [Configuration](#configuration)
-   1. [YAML Config File](#yaml-config-file)
-      1. [Yaml Jinja support](#yaml-jinja-support)
-   1. [Command Line Arguments](#command-line-arguments)
-1. [Running schemachange](#running-schemachange)
-   1. [Prerequisites](#prerequisites)
-   1. [Running The Script](#running-the-script)
-1. [Getting Started with schemachange](#getting-started-with-schemachange)
-1. [Integrating With DevOps](#integrating-with-devops)
-   1. [Sample DevOps Process Flow](#sample-devops-process-flow)
-   1. [Using in a CI/CD Pipeline](#using-in-a-cicd-pipeline)
-1. [Maintainers](#maintainers)
-1. [Third Party Packages](#third-party-packages)
-1. [Legal](#legal)
-
-
-## Project Structure
-
-### Folder Structure
-
-schemachange expects a directory structure like the following to exist:
-```
-(project_root)
-|
-|-- folder_1
-    |-- V1.1.1__first_change.sql
-    |-- V1.1.2__second_change.sql
-    |-- R__sp_add_sales.sql
-    |-- R__fn_get_timezone.sql
-|-- folder_2
-    |-- folder_3
-        |-- V1.1.3__third_change.sql
-        |-- R__fn_sort_ascii.sql
-```
-
-The schemachange folder structure is very flexible. The `project_root` folder is specified with the `-f` or `--root-folder` argument. schemachange only pays attention to the filenames, not the paths. Therefore, under the `project_root` folder you are free to arrange the change scripts any way you see fit. You can have as many subfolders (and nested subfolders) as you would like.
-
-## Change Scripts
-
-### Versioned Script Naming
-
-Versioned change scripts follow a similar naming convention to that used by [Flyway Versioned Migrations](https://flywaydb.org/documentation/migrations#versioned-migrations). The script name must follow this pattern (image taken from [Flyway docs](https://flywaydb.org/documentation/migrations#versioned-migrations)):
-
-<img src="images/flyway-naming-convention.png" alt="Flyway naming conventions" title="Flyway naming conventions" width="300" />
-
-With the following rules for each part of the filename:
-
-* **Prefix**: The letter 'V' for versioned change
-* **Version**: A unique version number with dots or underscores separating as many number parts as you like
-* **Separator**: __ (two underscores)
-* **Description**: An arbitrary description with words separated by underscores or spaces (can not include two underscores)
-* **Suffix**: .sql or .sql.jinja
-
-For example, a script name that follows this convention is: `V1.1.1__first_change.sql`. As with Flyway, the unique version string is very flexible. You just need to be consistent and always use the same convention, like 3 sets of numbers separated by periods. Here are a few valid version strings:
-
-* 1.1
-* 1_1
-* 1.2.3
-* 1_2_3
-
-Every script within a database folder must have a unique version number. schemachange will check for duplicate version numbers and throw an error if it finds any. This helps to ensure that developers who are working in parallel don't accidently (re-)use the same version number.
-
-### Repeatable Script Naming
-
-Repeatable change scripts follow a similar naming convention to that used by [Flyway Versioned Migrations](https://flywaydb.org/documentation/concepts/migrations.html#repeatable-migrations). The script name must follow this pattern (image taken from [Flyway docs](https://flywaydb.org/documentation/concepts/migrations.html#repeatable-migrations):
-
-<img src="images/flyway-repeatable-naming-convention.png" alt="Flyway naming conventions" title="Flyway naming conventions" width="300" />
-
-e.g:
-
-* R__sp_add_sales.sql
-* R__fn_get_timezone.sql
-* R__fn_sort_ascii.sql
-
-All repeatable change scripts are applied each time the utility is run, if there is a change in the file.
-Repeatable scripts could be used for maintaining code that always needs to be applied in its entirety. e.g. stores procedures, functions and view definitions etc.
-
-Just like Flyway, within a single migration run, repeatable scripts are always applied after all pending versioned scripts have been executed. Repeatable scripts are applied in alphabetical order of their description.
-
-### Always Script Naming
-
-Always change scripts are executed with every run of schemachange. This is an addition to the implementation of [Flyway Versioned Migrations](https://flywaydb.org/documentation/concepts/migrations.html#repeatable-migrations).
-The script name must following pattern:
-
-`A__Some_description.sql`
-
-e.g.
-
-* A__add_user.sql
-* A__assign_roles.sql
-
-This type of change script is useful for an environment set up after cloning. Always scripts are applied always last.
-
-### Script Requirements
-
-schemachange is designed to be very lightweight and not impose to many limitations. Each change script can have any number of SQL statements within it and must supply the necessary context, like database and schema names. The context can be supplied by using an explicit `USE <DATABASE>` command or by naming all objects with a three-part name (`<database name>.<schema name>.<object name>`). schemachange will simply run the contents of each script against the target Snowflake account, in the correct order.
-
-### Using Variables in Scripts
-schemachange supports the jinja engine for a variable replacement strategy. One important use of variables is to support multiple environments (dev, test, prod) in a single Snowflake account by dynamically changing the database name during deployment. To use a variable in a change script, use this syntax anywhere in the script: `{{ variable1 }}`.
-
-To pass variables to schemachange, check out the [Configuration](#configuration) section below. You can either use the `--vars` command line parameter or the YAML config file `schemachange-config.yml`. For the command line version you can pass variables like this: `--vars '{"variable1": "value", "variable2": "value2"}'`. This parameter accepts a flat JSON object formatted as a string. Nested objects and arrays don't make sense at this point and aren't supported.
-
-schemachange will replace any variable placeholders before running your change script code and will throw an error if it finds any variable placeholders that haven't been replaced.
-
-#### Secrets filtering
-While many CI/CD tools already have the capability to filter secrets, it is best that any tool also does not output secrets to the console or logs. Schemachange implements secrets filtering in a number of areas to ensure secrets are not writen to the console or logs. The only exception is the `render` command which will display secrets.
-
-A secret is just a standard variable that has been tagged as a secret. This is determined using a naming convention and either of the following will tag a variable as a secret:
-1. The variable name has the word secret in it.
-   ```yaml
-      config-version: 1
-      vars:
-         bucket_name: S3://......  # not a secret
-         secret_key: 567576D8E  # a secret
-   ```
-2. The variable is a child of a key named secrets.
-   ```yaml
-      config-version: 1
-      vars:
-      secrets:
-         my_key: 567576D8E # a secret
-      aws:
-         bucket_name: S3://......  # not a secret
-         secrets:
-            encryption_key: FGDSUUEHDHJK # a secret
-            us_east_1:
-               encryption_key: sdsdsd # a secret
-   ```
-
-### Jinja templating engine
-schemachange uses the Jinja templating engine internally and supports: [expressions](https://jinja.palletsprojects.com/en/3.0.x/templates/#expressions), [macros](https://jinja.palletsprojects.com/en/3.0.x/templates/#macros), [includes](https://jinja.palletsprojects.com/en/3.0.x/templates/#include) and [template inheritance](https://jinja.palletsprojects.com/en/3.0.x/templates/#template-inheritance).
-
-These files can be stored in the root-folder but schemachange also provides a separate modules folder `--modules-folder`. This allows common logic to be stored outside of the main changes scripts. The [demo/citibike_jinja](demo/citibike_jinja) has a simple example that demonstrates this.
-
-The Jinja autoescaping feature is disabled in schemachange, this feature in Jinja is currently designed for where the output language is HTML/XML. So if you are using schemachange with untrusted inputs you will need to handle this within your change scripts.
-
-### Gotchas
-
-Within change scripts:
-- [Snowflake Scripting blocks need delimiters](https://docs.snowflake.com/en/developer-guide/snowflake-scripting/running-examples#introduction)
-- [The last line can't be a comment](https://github.com/Snowflake-Labs/schemachange/issues/130)
-
-## Change History Table
-
-schemachange records all applied changes scripts to the change history table. By default schemachange will attempt to log all activities to the `METADATA.SCHEMACHANGE.CHANGE_HISTORY` table. The name and location of the change history table can be overriden by using the `-c` (or `--change-history-table`) parameter. The value passed to the parameter can have a one, two, or three part name (e.g. "TABLE_NAME", or "SCHEMA_NAME.TABLE_NAME", or "DATABASE_NAME.SCHEMA_NAME.TABLE_NAME"). This can be used to support multiple environments (dev, test, prod) or multiple subject areas within the same Snowflake account. By default schemachange will not try to create the change history table, and will fail if the table does not exist.
-
-Additionally, if the `--create-change-history-table` parameter is given, then schemachange will attempt to create the schema and table associated with the change history table. schemachange will not attempt to create the database for the change history table, so that must be created ahead of time, even when using the `--create-change-history-table` parameter.
-
-The structure of the `CHANGE_HISTORY` table is as follows:
-
-Column Name | Type |  Example
---- | --- | ---
-VERSION | VARCHAR | 1.1.1
-DESCRIPTION | VARCHAR | First change
-SCRIPT | VARCHAR | V1.1.1__first_change.sql
-SCRIPT_TYPE | VARCHAR | V
-CHECKSUM | VARCHAR | 38e5ba03b1a6d2...
-EXECUTION_TIME | NUMBER | 4
-STATUS | VARCHAR | Success
-INSTALLED_BY | VARCHAR | SNOWFLAKE_USER
-INSTALLED_ON | TIMESTAMP_LTZ | 2020-03-17 12:54:33.056 -0700
-
-A new row will be added to this table every time a change script has been applied to the database. schemachange will use this table to identify which changes have been applied to the database and will not apply the same version more than once.
-
-Here is the current schema DDL for the change history table (found in the [schemachange/cli.py](schemachange/cli.py) script), in case you choose to create it manually and not use the `--create-change-history-table` parameter:
-
-```sql
-CREATE TABLE IF NOT EXISTS SCHEMACHANGE.CHANGE_HISTORY
-(
-    VERSION VARCHAR
-   ,DESCRIPTION VARCHAR
-   ,SCRIPT VARCHAR
-   ,SCRIPT_TYPE VARCHAR
-   ,CHECKSUM VARCHAR
-   ,EXECUTION_TIME NUMBER
-   ,STATUS VARCHAR
-   ,INSTALLED_BY VARCHAR
-   ,INSTALLED_ON TIMESTAMP_LTZ
-)
-```
-
-## Authentication
-Schemachange supports snowflake's default authenticator, External Oauth, Browswer based SSO and Programmatic SSO options supported by the [Snowflake Python Connector](https://docs.snowflake.com/en/user-guide/python-connector-example.html#connecting-to-snowflake). Set the environment variable `SNOWFLAKE_AUTHENTICATOR` to one of the following
-Authentication Option | Expected Value
---- | ---
-Default [Password](https://docs.snowflake.com/en/user-guide/python-connector-example.html#connecting-using-the-default-authenticator) Authenticator | `snowflake`
-[Key Pair](https://docs.snowflake.com/en/user-guide/python-connector-example.html#using-key-pair-authentication) Authenticator| `snowflake`
-[External Oauth](https://docs.snowflake.com/en/user-guide/oauth-external.html) | `oauth`
-[Browser based SSO](https://docs.snowflake.com/en/user-guide/admin-security-fed-auth-use.html#setting-up-browser-based-sso) | `externalbrowser`
-[Programmatic SSO](https://docs.snowflake.com/en/user-guide/admin-security-fed-auth-use.html#native-sso-okta-only) (Okta Only) | Okta URL endpoing for your Okta account typically in the form `https://<okta_account_name>.okta.com` OR `https://<okta_account_name>.oktapreview.com`
-
-If an authenticator is unsupported, then schemachange will default to `snowflake`. If the authenticator is `snowflake`, and both password and key pair values are provided then schemachange will use the password over the key pair values.
-
-### Password Authentication
-The Snowflake user password for `SNOWFLAKE_USER` is required to be set in the environment variable `SNOWFLAKE_PASSWORD` prior to calling the script. schemachange will fail if the `SNOWFLAKE_PASSWORD` environment variable is not set. The environment variable `SNOWFLAKE_AUTHENTICATOR` will be set to `snowflake` if it not explicitly set.
-
-_**DEPRECATION NOTICE**: The `SNOWSQL_PWD` environment variable is deprecated but currently still supported. Support for it will be removed in a later version of schemachange. Please use `SNOWFLAKE_PASSWORD` instead._
-
-### Private Key Authentication
-The Snowflake user encrypted private key for `SNOWFLAKE_USER` is required to be in a file with the file path set in the environment variable `SNOWFLAKE_PRIVATE_KEY_PATH`. Additionally, the password for the encrypted private key file is required to be set in the environment variable `SNOWFLAKE_PRIVATE_KEY_PASSPHRASE`. If the variable is not set, schemachange will assume the private key is not encrypted. These two environment variables must be set prior to calling the script. Schemachange will fail if the `SNOWFLAKE_PRIVATE_KEY_PATH` is not set.
-
-### Oauth Authentication
-A Oauth Configuration can be made in the [YAML Config File](#yaml-config-file) or passing an equivalent json dictionary to the switch `--oauth-config`. Invoke this method by setting the environment variable `SNOWFLAKE_AUTHENTICATOR` to the value `oauth` prior to calling schemachange.  Since different Oauth providers may require different information the Oauth configuration uses four named variables that are fed into a POST request to obtain a token. Azure is shown in the example YAML but other providers should use a similar pattern and request payload contents.
-* token-provider-url
-The URL of the authenticator resource that will be receive the POST request.
-* token-response-name
-The Expected name of the JSON element containing the Token in the return response from the authenticator resource.
-* token-request-payload
-The Set of variables passed as a dictionary to the `data` element of the request.
-* token-request-headers
-The Set of variables passed as a dictionary to the `headers` element of the request.
-
-It is recomended to use the YAML file and pass oauth secrets into the configuration using the templating engine instead of the command line option.
-
-
-### External Browser Authentication
-External browser authentication can be used for local development by setting the environment variable `SNOWFLAKE_AUTHENTICATOR` to the value `externalbrowser` prior to calling schemachange.
-The client will be prompted to authenticate in a browser that pops up. Refer to the [documentation](https://docs.snowflake.com/en/user-guide/admin-security-fed-auth-use.html#setting-up-browser-based-sso) to cache the token to minimize the number of times the browser pops up to authenticate the user.
-
-### Okta Authentication
-For clients that do not have a browser, can use the popular SaaS Idp option to connect via Okta. This will require the Okta URL that you utilize for SSO.
-Okta authentication can be used setting the environment variable `SNOWFLAKE_AUTHENTICATOR` to the value of your okta endpoint as a fully formed URL ( E.g. `https://<org_name>.okta.com`) prior to calling schemachange.
-
-_** NOTE**: Please disable Okta MFA for the user who uses Native SSO authentication with client drivers. Please consult your Okta administrator for more information._
-
-## Configuration
-
-Parameters to schemachange can be supplied in two different ways:
-1. Through a YAML config file
-2. Via command line arguments
-
-If supplied by both the command line and the YAML file, The command line overides the YAML values.
-
-Additionally, regardless of the approach taken, the following paramaters are required to run schemachange:
-* snowflake-account
-* snowflake-user
-* snowflake-role
-* snowflake-warehouse
-
-Plese see [Usage Notes for the account Parameter (for the connect Method)](https://docs.snowflake.com/en/user-guide/python-connector-api.html#label-account-format-info) for more details on how to structure the account name.
-
-### YAML Config File
-
-schemachange expects the YAML config file to be named `schemachange-config.yml` and looks for it by default in the current folder. The folder can be overridden by using the `--config-folder` command line argument (see [Command Line Arguments](#command-line-arguments) below for more details).
-
-Here is the list of available configurations in the `schemachange-config.yml` file:
-
-```yaml
-config-version: 1
-
-# The root folder for the database change scripts
-root-folder: '/path/to/folder'
-
-# The modules folder for jinja macros and templates to be used across multiple scripts.
-modules-folder: null
-
-# The name of the snowflake account (e.g. xy12345.east-us-2.azure)
-snowflake-account: 'xy12345.east-us-2.azure'
-
-# The name of the snowflake user
-snowflake-user: 'user'
-
-# The name of the default role to use. Can be overrideen in the change scripts.
-snowflake-role: 'role'
-
-# The name of the default warehouse to use. Can be overridden in the change scripts.
-snowflake-warehouse: 'warehouse'
-
-# The name of the default database to use. Can be overridden in the change scripts.
-snowflake-database: null
-
-# The name of the default schema to use. Can be overridden in the change scripts.
-snowflake-schema: null
-
-# Used to override the default name of the change history table (the default is METADATA.SCHEMACHANGE.CHANGE_HISTORY)
-change-history-table: null
-
-# Define values for the variables to replaced in change scripts
-vars:
-  var1: 'value1'
-  var2: 'value2'
-  secrets:
-    var3: 'value3' # This is considered a secret and will not be displayed in any output
-
-# Create the change history schema and table, if they do not exist (the default is False)
-create-change-history-table: false
-
-# Enable autocommit feature for DML commands (the default is False)
-autocommit: false
-
-# Display verbose debugging details during execution (the default is False)
-verbose: false
-
-# Run schemachange in dry run mode (the default is False)
-dry-run: false
-
-# A string to include in the QUERY_TAG that is attached to every SQL statement executed
-query-tag: 'QUERY_TAG'
-
-# Information for Oauth token requests
-oauthconfig:
-  # url Where token request are posted to
-  token-provider-url: 'https://login.microsoftonline.com/{{ env_var('AZURE_ORG_GUID', 'default') }}/oauth2/v2.0/token'
-  # name of Json entity returned by request
-  token-response-name: 'access_token'
-  # Headers needed for successful post or other security markings ( multiple labeled items permitted
-  token-request-headers:
-    Content-Type: "application/x-www-form-urlencoded"
-    User-Agent: "python/schemachange"
-  # Request Payload for Token (it is recommended pass
-  token-request-payload:
-    client_id: '{{ env_var('CLIENT_ID', 'default') }}'
-    username: '{{ env_var('USER_ID', 'default') }}'
-    password: '{{ env_var('USER_PASSWORD', 'default') }}'
-    grant_type: 'password'
-    scope: '{{ env_var('SESSION_SCOPE', 'default') }}'
-```
-
-#### Yaml Jinja support
-The YAML config file supports the jinja templating language and has a custom function "env_var" to access environmental variables.  Jinja variables are unavailible and not yet loaded since they are supplied by the YAML file. Customisation of the YAML file can only happen through values passed via environment variables.
-
-##### env_var
-Provides access to environmental variables. The function can be used two different ways.
-
-Return the value of the environmental variable if it exists, otherwise return the default value.
-``` jinja
-{{ env_var('<environmental_variable>', 'default') }}
-```
-
-Return the value of the environmental variable if it exists, otherwise raise an error.
-``` jinja
-{{ env_var('<environmental_variable>') }}
-```
-
-### Command Line Arguments
-
-Schemachange supports a number of subcommands, it the subcommand is not provided it is defaulted to deploy. This behaviour keeps compatibility with versions prior to 3.2.
-
-#### deploy
-This is the main command that runs the deployment process.
-
-`usage: schemachange deploy [-h] [--config-folder CONFIG_FOLDER] [-f ROOT_FOLDER] [-m MODULES_FOLDER] [-a SNOWFLAKE_ACCOUNT] [-u SNOWFLAKE_USER] [-r SNOWFLAKE_ROLE] [-w SNOWFLAKE_WAREHOUSE] [-d SNOWFLAKE_DATABASE] [-s SNOWFLAKE_SCHEMA] [-c CHANGE_HISTORY_TABLE] [--vars VARS] [--create-change-history-table] [-ac] [-v] [--dry-run] [--query-tag QUERY_TAG]`
-
-Parameter | Description
---- | ---
--h, --help | Show the help message and exit
---config-folder CONFIG_FOLDER | The folder to look in for the schemachange-config.yml file (the default is the current working directory)
--f ROOT_FOLDER, --root-folder ROOT_FOLDER | The root folder for the database change scripts. The default is the current directory.
--m MODULES_FOLDER, --modules-folder MODULES_FOLDER | The modules folder for jinja macros and templates to be used across mutliple scripts
--a SNOWFLAKE_ACCOUNT, --snowflake-account SNOWFLAKE_ACCOUNT | The name of the snowflake account (e.g. xy12345.east-us-2.azure).
--u SNOWFLAKE_USER, --snowflake-user SNOWFLAKE_USER | The name of the snowflake user
--r SNOWFLAKE_ROLE, --snowflake-role SNOWFLAKE_ROLE | The name of the role to use
--w SNOWFLAKE_WAREHOUSE, --snowflake-warehouse SNOWFLAKE_WAREHOUSE | The name of the default warehouse to use. Can be overridden in the change scripts.
--d SNOWFLAKE_DATABASE, --snowflake-database SNOWFLAKE_DATABASE | The name of the default database to use. Can be overridden in the change scripts.
--s SNOWFLAKE_SCHEMA, --snowflake-schema SNOWFLAKE_SCHEMA | The name of the default schema to use. Can be overridden in the change scripts.
--c CHANGE_HISTORY_TABLE, --change-history-table CHANGE_HISTORY_TABLE | Used to override the default name of the change history table (which is METADATA.SCHEMACHANGE.CHANGE_HISTORY)
---vars VARS | Define values for the variables to replaced in change scripts, given in JSON format (e.g. '{"variable1": "value1", "variable2": "value2"}')
---create-change-history-table | Create the change history table if it does not exist. The default is 'False'.
--ac, --autocommit | Enable autocommit feature for DML commands. The default is 'False'.
--v, --verbose | Display verbose debugging details during execution. The default is 'False'.
---dry-run | Run schemachange in dry run mode. The default is 'False'.
---query-tag | A string to include in the QUERY_TAG that is attached to every SQL statement executed.
---oauth-config | Define values for the variables to Make Oauth Token requests  (e.g. {"token-provider-url": "https//...", "token-request-payload": {"client_id": "GUID_xyz",...},... })'
-
-#### render
-This subcommand is used to render a single script to the console. It is intended to support the development and troubleshooting of script that use features from the jinja template engine.
-
-`usage: schemachange render [-h] [--config-folder CONFIG_FOLDER] [-f ROOT_FOLDER] [-m MODULES_FOLDER] [--vars VARS] [-v] script`
-
-Parameter | Description
---- | ---
---config-folder CONFIG_FOLDER | The folder to look in for the schemachange-config.yml file (the default is the current working directory)
--f ROOT_FOLDER, --root-folder ROOT_FOLDER | The root folder for the database change scripts
--m MODULES_FOLDER, --modules-folder MODULES_FOLDER | The modules folder for jinja macros and templates to be used across multiple scripts
---vars VARS | Define values for the variables to replaced in change scripts, given in JSON format (e.g. {"variable1": "value1", "variable2": "value2"})
--v, --verbose | Display verbose debugging details during execution (the default is False)
-
-
-## Running schemachange
-
-### Prerequisites
-
-In order to run schemachange you must have the following:
-
-* You will need to have a recent version of python 3 installed
-* You will need to have the latest [Snowflake Python driver installed](https://docs.snowflake.com/en/user-guide/python-connector-install.html)
-* You will need to create the change history table used by schemachange in Snowflake (see [Change History Table](#change-history-table) above for more details)
-    * First, you will need to create a database to store your change history table (schemachange will not help you with this)
-    * Second, you will need to create the change history schema and table. You can do this manually (see [Change History Table](#change-history-table) above for the DDL) or have schemachange create them by running it with the `--create-change-history-table` parameter (just make sure the Snowflake user you're running schemachange with has privileges to create a schema and table in that database)
-* You will need to create (or choose) a user account that has privileges to apply the changes in your change script
-    * Don't forget that this user also needs the SELECT and INSERT privileges on the change history table
-
-### Running the Script
-
-schemachange is a single python script located at [schemachange/cli.py](schemachange/cli.py). It can be executed as follows:
-
-```
-python schemachange/cli.py [-h] [--config-folder CONFIG_FOLDER] [-f ROOT_FOLDER] [-a SNOWFLAKE_ACCOUNT] [-u SNOWFLAKE_USER] [-r SNOWFLAKE_ROLE] [-w SNOWFLAKE_WAREHOUSE] [-d SNOWFLAKE_DATABASE] [-s SNOWFLAKE_SCHEMA] [-c CHANGE_HISTORY_TABLE] [--vars VARS] [--create-change-history-table] [-ac] [-v] [--dry-run] [--query-tag QUERY_TAG] [--oauth-config OUATH_CONFIG]
-```
-
-Or if installed via `pip`, it can be executed as follows:
-
-```
-schemachange [-h] [--config-folder CONFIG_FOLDER] [-f ROOT_FOLDER] [-a SNOWFLAKE_ACCOUNT] [-u SNOWFLAKE_USER] [-r SNOWFLAKE_ROLE] [-w SNOWFLAKE_WAREHOUSE] [-d SNOWFLAKE_DATABASE] [-s SNOWFLAKE_SCHEMA] [-c CHANGE_HISTORY_TABLE] [--vars VARS] [--create-change-history-table] [-ac] [-v] [--dry-run] [--query-tag QUERY_TAG] [--oauth-config OUATH_CONFIG]
-```
-
-## Getting Started with schemachange
-
-The [demo](demo) folder in this project repository contains a schemachange demo project for you to try out. This demo is based on the standard Snowflake Citibike demo which can be found in [the Snowflake Hands-on Lab](https://docs.snowflake.net/manuals/other-resources.html#hands-on-lab). It contains the following database change scripts:
-
-Change Script | Description
---- | ---
-v1.1__initial_database_objects.sql | Create the initial Citibike demo objects including file formats, stages, and tables.
-v1.2__load_tables_from_s3.sql | Load the Citibike and weather data from the Snowlake lab S3 bucket.
-
-The [Citibike data](https://www.citibikenyc.com/system-data) for this demo comes from the NYC Citi Bike bike share program.
-
-To get started with schemachange and these demo Citibike scripts follow these steps:
-1. Make sure you've completed the [Prerequisites](#prerequisites) steps above
-1. Get a copy of this schemachange repository (either via a clone or download)
-1. Open a shell and change directory to your copy of the schemachange repository
-1. Run schemachange (see [Running the Script](#running-the-script) above) with your Snowflake account details and the `demo/citibike` folder as the root folder (make sure you use the full path)
-
-## Integrating With DevOps
-
-### Sample DevOps Process Flow
-
-Here is a sample DevOps development lifecycle with schemachange:
-
-<img src="images/diagram.png" alt="schemachange DevOps process" title="schemachange DevOps process" />
-
-### Using in a CI/CD Pipeline
-
-If your build agent has a recent version of python 3 installed, the script can be ran like so:
-```
-pip install schemachange --upgrade
-schemachange [-h] [-f ROOT_FOLDER] -a SNOWFLAKE_ACCOUNT -u SNOWFLAKE_USER -r SNOWFLAKE_ROLE -w SNOWFLAKE_WAREHOUSE [-d SNOWFLAKE_DATABASE] [-s SNOWFLAKE_SCHEMA] [-c CHANGE_HISTORY_TABLE] [--vars VARS] [--create-change-history-table] [-ac] [-v] [--dry-run] [--query-tag QUERY_TAG] [--oauth-config OUATH_CONFIG]
-```
-
-Or if you prefer docker, set the environment variables and run like so:
-```
-docker run -it --rm \
-  --name schemachange-script \
-  -v "$PWD":/usr/src/schemachange \
-  -w /usr/src/schemachange \
-  -e ROOT_FOLDER \
-  -e SNOWFLAKE_ACCOUNT \
-  -e SNOWFLAKE_USER \
-  -e SNOWFLAKE_ROLE \
-  -e SNOWFLAKE_WAREHOUSE \
-  -e SNOWFLAKE_PASSWORD \
-  python:3 /bin/bash -c "pip install schemachange --upgrade && schemachange -f $ROOT_FOLDER -a $SNOWFLAKE_ACCOUNT -u $SNOWFLAKE_USER -r $SNOWFLAKE_ROLE -w $SNOWFLAKE_WAREHOUSE"
-```
-
-Either way, don't forget to set the `SNOWFLAKE_PASSWORD` environment variable if using password authentication!
-
-## Maintainers
-
-- James Weakley (@jamesweakley)
-- Jeremiah Hansen (@jeremiahhansen)
-
-This is a community-developed tool, not an official Snowflake offering. It comes with no support or warranty. However, feel free to raise a github issue if you find a bug or would like a new feature.
-
-## Third Party Packages
-The current functionality in schemachange would not be possible without the following third party packages and all those that maintain and have contributed.
-
- Name | License | Author | URL
- ---|---|---|---
- Jinja2 | BSD License | Armin Ronacher | https://palletsprojects.com/p/jinja/
- PyYAML | MIT License | Kirill Simonov | https://pyyaml.org/
- pandas | BSD License | The Pandas Development Team | https://pandas.pydata.org
- pytest | MIT License | Holger Krekel, Bruno Oliveira, Ronny Pfannschmidt, Floris Bruynooghe, Brianna Laugher, Florian Bruhin and others | https://docs.pytest.org/en/latest/
- snowflake-connector-python | Apache Software License | Snowflake, Inc | https://www.snowflake.com/
-
-## Legal
-
-Licensed under the Apache License, Version 2.0 (the "License"); you may not use this tool except in compliance with the License. You may obtain a copy of the License at: [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-
-Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+import argparse
+import hashlib
+import json
+import os
+import pathlib
+import re
+import sys
+import textwrap
+import time
+import warnings
+from typing import Dict, Any, Optional, Set
+import jinja2
+import jinja2.ext
+import requests
+import snowflake.connector
+import yaml
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import serialization
+from jinja2.loaders import BaseLoader
+from pandas import DataFrame
+import pandas as pd
+import datetime
+from snowflake.connector.pandas_tools import write_pandas
+
+#region Global Variables
+# metadata
+_schemachange_version = '3.6.1'
+_config_file_name = 'schemachange-config.yml'
+_metadata_database_name = 'METADATA'
+_metadata_schema_name = 'SCHEMACHANGE'
+_metadata_table_name = 'CHANGE_HISTORY'
+_snowflake_application_name = 'schemachange'
+
+# messages
+_err_jinja_env_var = "Could not find environmental variable %s and no default" \
+  + " value was provided"
+_err_oauth_tk_nm = 'Response Json contains keys: {keys} \n but not {key}'
+_err_oauth_tk_err = '\n error description: {desc}'
+_err_no_auth_mthd = "Unable to find connection credentials for Okta, private key,  " \
+  + "password, Oauth or Browser authentication"
+_err_unsupported_auth_mthd = "'{unsupported_authenticator}' is not supported authenticator option. " \
+  + "Choose from externalbrowser, oauth, https://<subdomain>.okta.com. Using default value = 'snowflake'"
+_warn_password = "The SNOWSQL_PWD environment variable is deprecated and will" \
+  + " be removed in a later version of schemachange. Please use SNOWFLAKE_PASSWORD instead."
+_warn_password_dup = "Environment variables SNOWFLAKE_PASSWORD and SNOWSQL_PWD are " \
+  + " both present, using SNOWFLAKE_PASSWORD"
+_err_args_missing ="Missing config values. The following config values are required: %s "
+_err_env_missing ="Missing environment variable(s). \nSNOWFLAKE_PASSWORD must be defined for " \
+  + "password authentication. \nSNOWFLAKE_PRIVATE_KEY_PATH and (optional) " \
+  + "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE must be defined for private key authentication. " \
+  + "\nSNOWFLAKE_AUTHENTICATOR must be defined is using Oauth, OKTA or external Browser Authentication."
+_log_config_details = "Using Snowflake account {snowflake_account}\nUsing default role " \
+  + "{snowflake_role}\nUsing default warehouse {snowflake_warehouse}\nUsing default " \
+  + "database {snowflake_database}" \
+  + "schema {snowflake_schema}"
+_log_ch_use = "Using change history table {database_name}.{schema_name}.{table_name} " \
+  + "(last altered {last_altered})"
+_log_ch_create = "Created change history table {database_name}.{schema_name}.{table_name}"
+_err_ch_missing = "Unable to find change history table {database_name}.{schema_name}.{table_name}"
+_log_ch_max_version = "Max applied change script version: {max_published_version_display}"
+_log_skip_v = "Skipping change script {script_name} because it's older than the most recently " \
+  + "applied change ({max_published_version})"
+_log_skip_r ="Skipping change script {script_name} because there is no change since the last " \
+  + "execution"
+_log_apply =  "Applying change script {script_name}"
+_log_apply_set_complete  =  "Successfully applied {scripts_applied} change scripts (skipping " \
+  + "{scripts_skipped}) \nCompleted successfully"
+_err_vars_config = "vars did not parse correctly, please check its configuration"
+_err_vars_reserved = "The variable schemachange has been reserved for use by schemachange, " \
+  + "please use a different name"
+_err_invalid_folder  = "Invalid {folder_type} folder: {path}"
+_err_dup_scripts = "The script name {script_name} exists more than once (first_instance " \
+  + "{first_path}, second instance {script_full_path})"
+_err_dup_scripts_version = "The script version {script_version} exists more than once " \
+  + "(second instance {script_full_path})"
+_err_invalid_cht  = 'Invalid change history table name: %s'
+_log_auth_type ="Proceeding with %s authentication"
+_log_pk_enc ="No private key passphrase provided. Assuming the key is not encrypted."
+_log_okta_ep ="Okta Endpoint: %s"
+
+#endregion Global Variables
+
+class JinjaEnvVar(jinja2.ext.Extension):
+  """
+  Extends Jinja Templates with access to environmental variables
+  """
+  def __init__(self, environment: jinja2.Environment):
+    super().__init__(environment)
+
+    # add globals
+    environment.globals["env_var"] = JinjaEnvVar.env_var
+
+  @staticmethod
+  def env_var(env_var: str, default: Optional[str] = None) -> str:
+    """
+    Returns the value of the environmental variable or the default.
+    """
+    result = default
+    if env_var in os.environ:
+      result = os.environ[env_var]
+
+    if result is None:
+      raise ValueError(_err_jinja_env_var % env_var)
+
+    return result
+
+
+class JinjaTemplateProcessor:
+  _env_args = {"undefined":jinja2.StrictUndefined,"autoescape":False, "extensions":[JinjaEnvVar]}
+
+  def __init__(self, project_root: str, modules_folder: str = None):
+    loader: BaseLoader
+    if modules_folder:
+      loader = jinja2.ChoiceLoader(
+        [
+          jinja2.FileSystemLoader(project_root),
+          jinja2.PrefixLoader({"modules": jinja2.FileSystemLoader(modules_folder)}),
+        ]
+      )
+    else:
+      loader = jinja2.FileSystemLoader(project_root)
+    self.__environment = jinja2.Environment(loader=loader, **self._env_args)
+    self.__project_root = project_root
+
+  def list(self):
+    return self.__environment.list_templates()
+
+  def override_loader(self, loader: jinja2.BaseLoader):
+    # to make unit testing easier
+    self.__environment = jinja2.Environment(loader=loader, **self._env_args)
+
+  def render(self, script: str, vars: Dict[str, Any], verbose: bool) -> str:
+    if not vars:
+      vars = {}
+    # jinja needs posix path
+    posix_path = pathlib.Path(script).as_posix()
+    template = self.__environment.get_template(posix_path)
+    content = template.render(**vars).strip()
+    content = content[:-1] if content.endswith(';') else content
+    return content
+
+  def relpath(self, file_path: str):
+    return os.path.relpath(file_path, self.__project_root)
+
+
+class SecretManager:
+  """
+  Provides the ability to redact secrets
+  """
+  __singleton: 'SecretManager'
+
+  @staticmethod
+  def get_global_manager() -> 'SecretManager':
+    return SecretManager.__singleton
+
+  @staticmethod
+  def set_global_manager(global_manager: 'SecretManager'):
+    SecretManager.__singleton = global_manager
+
+  @staticmethod
+  def global_redact(context: str) -> str:
+    """
+    redacts any text that has been classified a secret
+    using the global SecretManager instance.
+    """
+    return SecretManager.__singleton.redact(context)
+
+  def __init__(self):
+    self.__secrets = set()
+
+  def clear(self):
+    self.__secrets = set()
+
+  def add(self, secret: str):
+    if secret:
+      self.__secrets.add(secret)
+
+  def add_range(self, secrets: Set[str]):
+    if secrets:
+      self.__secrets = self.__secrets | secrets
+
+  def redact(self, context: str) -> str:
+    """
+    redacts any text that has been classified a secret
+    """
+    redacted = context
+    if redacted:
+      for secret in self.__secrets:
+        redacted = redacted.replace(secret, "*" * len(secret))
+    return redacted
+
+class RepeatableMigrationBatchItem:
+  def __init__(self, script_name: str, script_number: int, content: str, checksum: str):
+    self.script_name = script_name
+    self.script_number = script_number
+    self.content = content
+    self.checksum = checksum
+
+  def get_clean_script_name(self) -> str:
+    index = self.script_name.index("__") + len("__")
+    return self.script_name[index:].replace("_", " ")
+
+class SnowflakeSchemachangeSession:
+  """
+  Manages Snowflake Interactions and authentication
+  """
+  #region Query Templates
+  _q_ch_metadata =  "SELECT CREATED, LAST_ALTERED FROM {database_name}.INFORMATION_SCHEMA.TABLES" \
+    + " WHERE TABLE_SCHEMA = REPLACE('{schema_name}','\"','') AND TABLE_NAME = replace('{table_name}','\"','')"
+  _q_ch_schema_present = "SELECT COUNT(1) FROM {database_name}.INFORMATION_SCHEMA.SCHEMATA" \
+    + " WHERE SCHEMA_NAME = REPLACE('{schema_name}','\"','')"
+  _q_ch_ddl_schema = "CREATE SCHEMA {schema_name}"
+  _q_ch_ddl_table = "CREATE TABLE IF NOT EXISTS {database_name}.{schema_name}.{table_name} (VERSION VARCHAR, " \
+    + "DESCRIPTION VARCHAR, SCRIPT VARCHAR, SCRIPT_TYPE VARCHAR, CHECKSUM VARCHAR," \
+    + " EXECUTION_TIME NUMBER, STATUS VARCHAR, INSTALLED_BY VARCHAR, INSTALLED_ON TIMESTAMP_LTZ)"
+  _q_ch_r_checksum = "SELECT DISTINCT SCRIPT, FIRST_VALUE(CHECKSUM) OVER (PARTITION BY SCRIPT " \
+    + "ORDER BY INSTALLED_ON DESC) FROM {database_name}.{schema_name}.{table_name} WHERE SCRIPT_TYPE = 'R' AND " \
+    + "STATUS = 'Success'"
+  _q_ch_fetch ="SELECT VERSION FROM {database_name}.{schema_name}.{table_name} WHERE SCRIPT_TYPE = 'V' ORDER" \
+    + " BY INSTALLED_ON DESC LIMIT 1"
+  _q_sess_tag = "ALTER SESSION SET QUERY_TAG = '{query_tag}'"
+  _q_ch_log = "INSERT INTO {database_name}.{schema_name}.{table_name} (VERSION, DESCRIPTION, SCRIPT, SCRIPT_TYPE, " \
+    + "CHECKSUM, EXECUTION_TIME, STATUS, INSTALLED_BY, INSTALLED_ON) values ('{script_version}'," \
+    + "'{script_description}','{script_name}','{script_type}','{checksum}',{execution_time}," \
+    + "'{status}','{user}',CURRENT_TIMESTAMP);"
+  _q_set_sess_role = 'USE ROLE {role};'
+  _q_set_sess_database = 'USE DATABASE {database};'
+  _q_set_sess_schema = 'USE SCHEMA {schema};'
+  _q_set_sess_warehouse = 'USE WAREHOUSE {warehouse};'
+   #endregion Query Templates
+
+
+  def __init__(self, config):
+    session_parameters = {
+        "QUERY_TAG": "schemachange %s" % _schemachange_version
+        }
+    if config['query_tag']:
+      session_parameters["QUERY_TAG"] += ";%s" % config['query_tag']
+
+    # Retreive Connection info from config dictionary
+    self.conArgs = {"user": config['snowflake_user'],"account": config['snowflake_account'] \
+      ,"role": config['snowflake_role'],"warehouse": config['snowflake_warehouse'] \
+      ,"database": config['snowflake_database'],"schema": config['snowflake_schema'], "application": _snowflake_application_name \
+      ,"session_parameters":session_parameters}
+
+    self.oauth_config = config['oauth_config']
+    self.autocommit = config['autocommit']
+    self.verbose = config['verbose']
+    if self.set_connection_args():
+      self.con = snowflake.connector.connect(**self.conArgs)
+      if not self.autocommit:
+        self.con.autocommit(False)
+    else:
+      print(_err_env_missing)
+
+  def __del__(self):
+    if hasattr(self, 'con'):
+      self.con.close()
+
+  def get_oauth_token(self):
+    req_info = { \
+      "url":self.oauth_config['token-provider-url'], \
+      "headers":self.oauth_config['token-request-headers'], \
+      "data":self.oauth_config['token-request-payload'] \
+    }
+    token_name = self.oauth_config['token-response-name']
+    response = requests.post(**req_info)
+    resJsonDict =json.loads(response.text)
+    try: return resJsonDict[token_name]
+    except KeyError:
+      errormessage = _err_oauth_tk_nm.format(
+        keys = ', '.join(resJsonDict.keys()),
+        key = token_name
+      )
+      # if there is an error passed with the reponse include that
+      if 'error_description' in resJsonDict.keys():
+        errormessage += _err_oauth_tk_err.format(desc=resJsonDict['error_description'])
+      raise KeyError( errormessage )
+
+  def set_connection_args(self):
+    # Password authentication is the default
+    snowflake_password = None
+    default_authenticator = 'snowflake'
+    if os.getenv("SNOWFLAKE_PASSWORD") is not None and os.getenv("SNOWFLAKE_PASSWORD"):
+      snowflake_password = os.getenv("SNOWFLAKE_PASSWORD")
+
+    # Check legacy/deprecated env variable
+    if os.getenv("SNOWSQL_PWD") is not None and os.getenv("SNOWSQL_PWD"):
+      if snowflake_password:
+        warnings.warn(_warn_password_dup, DeprecationWarning)
+      else:
+        warnings.warn(_warn_password, DeprecationWarning)
+        snowflake_password = os.getenv("SNOWSQL_PWD")
+
+    snowflake_authenticator = os.getenv("SNOWFLAKE_AUTHENTICATOR")
+
+    if snowflake_authenticator:
+      # Determine the type of Authenticator
+      # OAuth based authentication
+      if snowflake_authenticator.lower() == 'oauth':
+        oauth_token = self.get_oauth_token()
+
+        if self.verbose:
+          print( _log_auth_type % 'Oauth Access Token')
+        self.conArgs['token'] = oauth_token
+        self.conArgs['authenticator'] = 'oauth'
+      # External Browswer based SSO
+      elif snowflake_authenticator.lower() == 'externalbrowser':
+        self.conArgs['authenticator'] = 'externalbrowser'
+        if self.verbose:
+          print(_log_auth_type % 'External Browser')
+      # IDP based Authentication, limited to Okta
+      elif snowflake_authenticator.lower()[:8]=='https://':
+
+        if self.verbose:
+          print(_log_auth_type % 'Okta')
+          print(_log_okta_ep % snowflake_authenticator)
+
+        self.conArgs['password'] = snowflake_password
+        self.conArgs['authenticator'] = snowflake_authenticator.lower()
+      elif snowflake_authenticator.lower() == 'snowflake':
+        self.conArgs['authenticator'] = default_authenticator
+      # if authenticator is not a supported method or the authenticator variable is defined but not specified
+      else:
+        # defaulting to snowflake as authenticator
+        if self.verbose:
+          print(_err_unsupported_auth_mthd.format(unsupported_authenticator=snowflake_authenticator) )
+        self.conArgs['authenticator'] = default_authenticator
+    else:
+        # default authenticator to snowflake
+        self.conArgs['authenticator'] = default_authenticator
+
+    if self.conArgs['authenticator'].lower() == default_authenticator:
+      # Giving preference to password based authentication when both private key and password are specified.
+      if snowflake_password:
+        if self.verbose:
+          print(_log_auth_type %  'password' )
+        self.conArgs['password'] = snowflake_password
+
+      elif os.getenv("SNOWFLAKE_PRIVATE_KEY_PATH", ''):
+        if self.verbose:
+          print( _log_auth_type %  'private key')
+
+        private_key_password = os.getenv("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE", '')
+        if private_key_password:
+          private_key_password = private_key_password.encode()
+        else:
+          private_key_password = None
+          if self.verbose:
+            print(_log_pk_enc)
+        with open(os.environ["SNOWFLAKE_PRIVATE_KEY_PATH"], "rb") as key:
+          p_key= serialization.load_pem_private_key(
+              key.read(),
+              password = private_key_password,
+              backend = default_backend()
+          )
+
+        pkb = p_key.private_bytes(
+            encoding = serialization.Encoding.DER,
+            format = serialization.PrivateFormat.PKCS8,
+            encryption_algorithm = serialization.NoEncryption())
+
+        self.conArgs['private_key'] = pkb
+      else:
+        raise NameError(_err_no_auth_mthd)
+
+    return True
+
+  def execute_snowflake_query(self, query):
+    if self.verbose:
+      print(SecretManager.global_redact("SQL query: %s" % query))
+    try:
+      res = self.con.execute_string(query)
+      if not self.autocommit:
+        self.con.commit()
+      return res
+    except Exception as e:
+      if not self.autocommit:
+        self.con.rollback()
+      raise e
+
+  def execute_pandas_df(self, df: pd.DataFrame, change_history_table: dict):
+    if self.verbose:
+      print(SecretManager.global_redact("SQL query: %s" % df.to_string()))
+
+    try:
+      success, nchunks, nrows, _ = write_pandas(self.con, df, table_name=change_history_table['table_name'],\
+                                                database=change_history_table['database_name'],\
+                                                schema=change_history_table['schema_name'])
+      if not self.autocommit:
+        self.con.commit()
+      return success
+    except Exception as e:
+      if not self.autocommit:
+        self.con.rollback()
+      raise e
+
+  def execute_snowflake_batch_query(self, query):
+    if self.verbose:
+      print(SecretManager.global_redact("SQL query: %s" % query))
+    try:
+      res = self.con.execute_string(query)
+      if not self.autocommit:
+        self.con.commit()
+      return (True, "Success")
+    except Exception as e:
+      if not self.autocommit:
+        self.con.rollback()
+      return (False, e)
+
+  def fetch_change_history_metadata(self,change_history_table):
+    # This should only ever return 0 or 1 rows
+    query = self._q_ch_metadata.format(**change_history_table)
+    results = self.execute_snowflake_query(query)
+
+    # Collect all the results into a list
+    change_history_metadata = dict()
+    for cursor in results:
+      for row in cursor:
+        change_history_metadata['created'] = row[0]
+        change_history_metadata['last_altered'] = row[1]
+
+    return change_history_metadata
+
+  def create_change_history_table_if_missing(self, change_history_table):
+    # Check if schema exists
+    query = self._q_ch_schema_present.format(**change_history_table)
+    results = self.execute_snowflake_query(query)
+    schema_exists = False
+    for cursor in results:
+      for row in cursor:
+        schema_exists = (row[0] > 0)
+
+    # Create the schema if it doesn't exist
+    if not schema_exists:
+      query = self._q_ch_ddl_schema.format(**change_history_table)
+      self.execute_snowflake_query(query)
+
+    # Finally, create the change history table if it doesn't exist
+    query = self._q_ch_ddl_table.format(**change_history_table)
+    self.execute_snowflake_query(query)
+
+  def fetch_r_scripts_checksum(self,change_history_table):
+    query = self._q_ch_r_checksum.format(**change_history_table)
+    results = self.execute_snowflake_query(query)
+
+    # Collect all the results into a dict
+    d_script_checksum = DataFrame(columns=['script_name', 'checksum'])
+    script_names = []
+    checksums = []
+    for cursor in results:
+      for row in cursor:
+        script_names.append(row[0])
+        checksums.append(row[1])
+
+    d_script_checksum['script_name'] = script_names
+    d_script_checksum['checksum'] = checksums
+    return d_script_checksum
+
+  def fetch_change_history(self, change_history_table):
+    query = self._q_ch_fetch.format(**change_history_table)
+    results = self.execute_snowflake_query(query)
+
+    # Collect all the results into a list
+    change_history = list()
+    for cursor in results:
+      for row in cursor:
+        change_history.append(row[0])
+
+    return change_history
+
+  def reset_session(self):
+    # These items are optional, so we can only reset the ones with values
+    reset_query = ""
+    if self.conArgs['role']:
+      reset_query += self._q_set_sess_role.format(**self.conArgs) + " "
+    if self.conArgs['warehouse']:
+      reset_query += self._q_set_sess_warehouse.format(**self.conArgs) + " "
+    if self.conArgs['database']:
+      reset_query += self._q_set_sess_database.format(**self.conArgs) + " "
+    if self.conArgs['schema']:
+      reset_query += self._q_set_sess_schema.format(**self.conArgs) + " "
+
+    self.execute_snowflake_query(reset_query)
+
+  def reset_query_tag(self, extra_tag = None):
+    query_tag = self.conArgs["session_parameters"]["QUERY_TAG"]
+    if extra_tag:
+      query_tag += f";{extra_tag}"
+
+    self.execute_snowflake_query(self._q_sess_tag.format(query_tag=query_tag))
+
+  def apply_change_script(self, script, script_content, change_history_table):
+    # Define a few other change related variables
+    checksum = hashlib.sha224(script_content.encode('utf-8')).hexdigest()
+    execution_time = 0
+    status = 'Success'
+
+    # Execute the contents of the script
+    if len(script_content) > 0:
+      start = time.time()
+      self.reset_session()
+      self.reset_query_tag(script['script_name'])
+      self.execute_snowflake_query(script_content)
+      self.reset_query_tag()
+      self.reset_session()
+      end = time.time()
+      execution_time = round(end - start)
+
+    # Finally record this change in the change history table by gathering data
+    frmt_args = script.copy()
+    frmt_args.update(change_history_table)
+    frmt_args['checksum'] =checksum
+    frmt_args['execution_time'] =execution_time
+    frmt_args['status'] =status
+    frmt_args['user'] =self.conArgs['user']
+    # Compose and execute the insert statement to the log file
+    query = self._q_ch_log.format(**frmt_args)
+    self.execute_snowflake_query(query)
+
+  def apply_batch_change_script(self, scripts: list[RepeatableMigrationBatchItem], change_history_table):
+
+    script_content = ";\n".join([script.content for script in scripts])
+
+    # Execute the contents of the script
+    if len(script_content) > 0:
+      start = time.time()
+      self.reset_session()
+      self.reset_query_tag("SchemaChange_Batch_Repeatable Count:" + str(len(scripts)))
+      batch_processed_successfully = self.execute_snowflake_batch_query(script_content)
+      self.reset_query_tag()
+      self.reset_session()
+      end = time.time()
+      execution_time = round(end - start)
+
+      if batch_processed_successfully[0]:
+        df = pd.DataFrame(index=range(len(scripts)), columns=['VERSION', 'DESCRIPTION', 'SCRIPT', 'SCRIPT_TYPE',
+                                                              'CHECKSUM', 'EXECUTION_TIME', 'STATUS', 'INSTALLED_BY',
+                                                              'INSTALLED_ON'])
+
+        for i in range(len(scripts)):
+          df.loc[i] = [None, scripts[i].get_clean_script_name(), scripts[i].script_name, "R", scripts[i].checksum,
+                       execution_time, "Success", self.conArgs['user'], datetime.datetime.now().astimezone()]
+
+        self.execute_pandas_df(df, change_history_table)
+      else:
+        count = len(scripts) // 2
+        if len(scripts) == 1:
+          raise Exception(batch_processed_successfully[1])
+
+        self.apply_batch_change_script(scripts[:count], change_history_table)
+
+        self.apply_batch_change_script(scripts[count:], change_history_table)
+
+def deploy_command(config):
+  # Make sure we have the required connection info, all of the below needs to be present.
+  req_args = set(['snowflake_account','snowflake_user','snowflake_role','snowflake_warehouse'])
+  provided_args = {k:v for (k,v) in config.items() if v}
+  missing_args = req_args -provided_args.keys()
+  if len(missing_args)>0:
+    raise ValueError(_err_args_missing % ', '.join({s.replace('_', ' ') for s in missing_args}))
+
+  #ensure an authentication method is specified / present. one of the below needs to be present.
+  req_env_var = set(['SNOWFLAKE_PASSWORD', 'SNOWSQL_PWD','SNOWFLAKE_PRIVATE_KEY_PATH','SNOWFLAKE_AUTHENTICATOR'])
+  if len((req_env_var - dict(os.environ).keys()))==len(req_env_var):
+    raise ValueError(_err_env_missing)
+
+  # Log some additional details
+  if config['dry_run']:
+    print("Running in dry-run mode")
+  print(_log_config_details.format(**config))
+
+  #connect to snowflake and maintain connection
+  session = SnowflakeSchemachangeSession(config)
+
+  scripts_skipped = 0
+  scripts_applied = 0
+
+  # Deal with the change history table (create if specified)
+  change_history_table = get_change_history_table_details(config['change_history_table'])
+  change_history_metadata = session.fetch_change_history_metadata(change_history_table)
+  if change_history_metadata:
+    print(_log_ch_use.format(last_altered=change_history_metadata['last_altered'], **change_history_table))
+  elif config['create_change_history_table']:
+    # Create the change history table (and containing objects) if it don't exist.
+    if not config['dry_run']:
+      session.create_change_history_table_if_missing(change_history_table)
+    print(_log_ch_create.format(**change_history_table))
+  else:
+    raise ValueError(_err_ch_missing.format(**change_history_table))
+
+  # Find the max published version
+  max_published_version = ''
+
+  change_history = None
+  r_scripts_checksum = None
+  if (config['dry_run'] and change_history_metadata) or not config['dry_run']:
+    change_history = session.fetch_change_history(change_history_table)
+    r_scripts_checksum = session.fetch_r_scripts_checksum(change_history_table)
+
+  if change_history:
+    max_published_version = change_history[0]
+  max_published_version_display = max_published_version
+  if max_published_version_display == '':
+    max_published_version_display = 'None'
+  print(_log_ch_max_version.format(max_published_version_display=max_published_version_display))
+
+  # Find all scripts in the root folder (recursively) and sort them correctly
+  all_scripts = get_all_scripts_recursively(config['root_folder'], config['verbose'])
+  all_script_names = list(all_scripts.keys())
+
+  # If batch sizes are set then pull through that setting, otherwise set the batch to 1 to keep existing functionality
+  batch_size = config.get("batch_migration_count", 1)
+
+  # Sort scripts such that versioned scripts get applied first and then the repeatable ones.
+  versioned_script_names = sorted_alphanumeric([script for script in all_script_names if script[0] == 'V'])
+  repeatable_script_names = sorted_alphanumeric([script for script in all_script_names if script[0] == 'R'])
+  always_script_names = sorted_alphanumeric([script for script in all_script_names if script[0] == 'A'])
+
+  # Loop through each script in order and apply any required changes
+  for script_name in versioned_script_names:
+    script = all_scripts[script_name]
+
+    # Apply a versioned-change script only if the version is newer than the most recent change in the database
+    # Apply any other scripts, i.e. repeatable scripts, irrespective of the most recent change in the database
+    if get_alphanum_key(script['script_version']) <= get_alphanum_key(max_published_version):
+      if config['verbose']:
+        print(_log_skip_v.format(max_published_version=max_published_version, **script) )
+      scripts_skipped += 1
+    else:
+      # Always process with jinja engine
+      jinja_processor = JinjaTemplateProcessor(project_root = config['root_folder'], modules_folder = config['modules_folder'])
+      content = jinja_processor.render(jinja_processor.relpath(script['script_full_path']), config['vars'], config['verbose'])
+
+      print(_log_apply.format(**script))
+      if not config['dry_run']:
+        session.apply_change_script(script, content, change_history_table)
+
+      scripts_applied += 1
+
+  # Run the repeatable scripts and batch together if needed
+  scripts_to_run_in_batch = []
+  total_repeatable_count = len(repeatable_script_names)
+  for script_name in repeatable_script_names:
+    script = all_scripts[script_name]
+
+    jinja_processor = JinjaTemplateProcessor(project_root=config['root_folder'],
+                                             modules_folder=config['modules_folder'])
+    content = jinja_processor.render(jinja_processor.relpath(script['script_full_path']), config['vars'],
+                                     config['verbose'])
+
+    # Compute the checksum for the script
+    checksum_current = hashlib.sha224(content.encode('utf-8')).hexdigest()
+
+    # check if R file was already executed
+    if (r_scripts_checksum is not None) and script_name in list(r_scripts_checksum['script_name']):
+      checksum_last = list(r_scripts_checksum.loc[r_scripts_checksum['script_name'] == script_name, 'checksum'])[0]
+    else:
+      checksum_last = ''
+
+    # check if there is a change of the checksum in the script
+    if checksum_current == checksum_last:
+      if config['verbose']:
+        print(_log_skip_r.format(**script))
+      scripts_skipped += 1
+      continue
+
+    # If more records can be added to the list of batches then add it
+    if not config['dry_run'] and batch_size > 1 and len(scripts_to_run_in_batch) < batch_size:
+      checksum = hashlib.sha224(content.encode('utf-8')).hexdigest()
+      scripts_to_run_in_batch.append(RepeatableMigrationBatchItem(script_name, batch_size, content, checksum))
+
+      # If the batch size is hit or all of the remaining records are added then apply the changes and update the counts
+      if len(scripts_to_run_in_batch) == batch_size or len(scripts_to_run_in_batch) == total_repeatable_count:
+        session.apply_batch_change_script(scripts_to_run_in_batch, change_history_table)
+        scripts_applied += len(scripts_to_run_in_batch)
+        total_repeatable_count -= len(scripts_to_run_in_batch)
+        scripts_to_run_in_batch = []
+
+    # If batch size is 1 then run the code normally
+    elif not config['dry_run'] and batch_size == 1:
+      session.apply_change_script(script, content, change_history_table)
+      scripts_applied += 1
+
+  # Run the always scripts
+  for script_name in always_script_names:
+    script = all_scripts[script_name]
+
+    # Always process with jinja engine
+    jinja_processor = JinjaTemplateProcessor(project_root = config['root_folder'], modules_folder = config['modules_folder'])
+    content = jinja_processor.render(jinja_processor.relpath(script['script_full_path']), config['vars'], config['verbose'])
+
+    print(_log_apply.format(**script))
+    if not config['dry_run']:
+      session.apply_change_script(script, content, change_history_table)
+
+    scripts_applied += 1
+
+  print(_log_apply_set_complete.format(scripts_applied=scripts_applied, scripts_skipped=scripts_skipped))
+
+def render_command(config, script_path):
+  """
+  Renders the provided script.
+
+  Note: does not apply secrets filtering.
+  """
+  # Validate the script file path
+  script_path = os.path.abspath(script_path)
+  if not os.path.isfile(script_path):
+    raise ValueError(_err_invalid_folder.format(folder_type='script_path', path=script_path))
+  # Always process with jinja engine
+  jinja_processor = JinjaTemplateProcessor(project_root = config['root_folder'], \
+     modules_folder = config['modules_folder'])
+  content = jinja_processor.render(jinja_processor.relpath(script_path), \
+    config['vars'], config['verbose'])
+
+  checksum = hashlib.sha224(content.encode('utf-8')).hexdigest()
+  print("Checksum %s" % checksum)
+  print(content)
+
+
+# This function will return a list containing the parts of the key (split by number parts)
+# Each number is converted to and integer and string parts are left as strings
+# This will enable correct sorting in python when the lists are compared
+# e.g. get_alphanum_key('1.2.2') results in ['', 1, '.', 2, '.', 2, '']
+def get_alphanum_key(key):
+  convert = lambda text: int(text) if text.isdigit() else text.lower()
+  alphanum_key = [ convert(c) for c in re.split('([0-9]+)', key) ]
+  return alphanum_key
+
+def sorted_alphanumeric(data):
+  return sorted(data, key=get_alphanum_key)
+
+def load_schemachange_config(config_file_path: str) -> Dict[str, Any]:
+  """
+  Loads the schemachange config file and processes with jinja templating engine
+  """
+  config = dict()
+
+  # First read in the yaml config file, if present
+  if os.path.isfile(config_file_path):
+    with open(config_file_path) as config_file:
+      # Run the config file through the jinja engine to give access to environmental variables
+      # The config file does not have the same access to the jinja functionality that a script
+      # has.
+      config_template = jinja2.Template(config_file.read(), undefined=jinja2.StrictUndefined, extensions=[JinjaEnvVar])
+
+      # The FullLoader parameter handles the conversion from YAML scalar values to Python the dictionary format
+      config = yaml.load(config_template.render(), Loader=yaml.FullLoader)
+    print("Using config file: %s" % config_file_path)
+  return config
+
+def get_schemachange_config(config_file_path, root_folder, modules_folder, snowflake_account, \
+  snowflake_user, snowflake_role, snowflake_warehouse, snowflake_database, snowflake_schema, \
+  change_history_table, vars, create_change_history_table, autocommit, verbose, \
+  dry_run, query_tag, oauth_config, batch_migration_count, **kwargs):
+
+  # create cli override dictionary
+  # Could refactor to just pass Args as a dictionary?
+  # **kwargs inlcuded to avoid complaints about unexpect arguments from arg parser eg:subcommand
+  cli_inputs = { "root_folder":root_folder, \
+    "modules_folder":modules_folder, "snowflake_account":snowflake_account, \
+    "snowflake_user":snowflake_user, "snowflake_role":snowflake_role, \
+    "snowflake_warehouse":snowflake_warehouse, "snowflake_database":snowflake_database, \
+    "snowflake_schema":snowflake_schema, \
+    "change_history_table":change_history_table, "vars":vars, \
+    "create_change_history_table":create_change_history_table, \
+    "autocommit":autocommit, "verbose":verbose, "dry_run":dry_run,\
+    "query_tag":query_tag, "oauth_config":oauth_config, "batch_migration_count": batch_migration_count}
+  cli_inputs = {k:v for (k,v) in cli_inputs.items() if v}
+
+  # load YAML inputs and convert kebabs to snakes
+  config = {k.replace('-','_'):v for (k,v) in load_schemachange_config(config_file_path).items()}
+  # set values passed into the cli Overriding values in config file
+  config.update(cli_inputs)
+
+  # create Default values dictionary
+  config_defaults =  {"root_folder":os.path.abspath('.'), "modules_folder":None,  \
+    "snowflake_account":None,  "snowflake_user":None, "snowflake_role":None,   \
+    "snowflake_warehouse":None,  "snowflake_database":None, "snowflake_schema":None, \
+    "change_history_table":None,  \
+    "vars":{}, "create_change_history_table":False, "autocommit":False, "verbose":False,  \
+    "dry_run":False , "query_tag":None , "oauth_config":None }
+  #insert defualt values for items not populated
+  config.update({ k:v for (k,v) in config_defaults.items() if not k in config.keys()})
+
+  # Validate folder paths
+  if 'root_folder' in config:
+    config['root_folder'] = os.path.abspath(config['root_folder'])
+  if not os.path.isdir(config['root_folder']):
+    raise ValueError(_err_invalid_folder.format(folder_type='root', path=config['root_folder']))
+
+  if config['modules_folder']:
+    config['modules_folder'] = os.path.abspath(config['modules_folder'])
+    if not os.path.isdir(config['modules_folder']):
+      raise ValueError(_err_invalid_folder.format(folder_type='modules', path=config['modules_folder']))
+  if config['vars']:
+    # if vars is configured wrong in the config file it will come through as a string
+    if type(config['vars']) is not dict:
+      raise ValueError(_err_vars_config)
+
+    # the variable schema change has been reserved
+    if "schemachange" in config['vars']:
+      raise ValueError(_err_vars_reserved)
+
+  return config
+
+def get_all_scripts_recursively(root_directory, verbose):
+  all_files = dict()
+  all_versions = list()
+  # Walk the entire directory structure recursively
+  for (directory_path, directory_names, file_names) in os.walk(root_directory):
+    for file_name in file_names:
+
+      file_full_path = os.path.join(directory_path, file_name)
+      script_name_parts = re.search(r'^([V])(.+?)__(.+?)\.(?:sql|sql.jinja)$', \
+        file_name.strip(), re.IGNORECASE)
+      repeatable_script_name_parts = re.search(r'^([R])__(.+?)\.(?:sql|sql.jinja)$', \
+        file_name.strip(), re.IGNORECASE)
+      always_script_name_parts = re.search(r'^([A])__(.+?)\.(?:sql|sql.jinja)$', \
+        file_name.strip(), re.IGNORECASE)
+
+      # Set script type depending on whether it matches the versioned file naming format
+      if script_name_parts is not None:
+        script_type = 'V'
+        if verbose:
+          print("Found Versioned file " + file_full_path)
+      elif repeatable_script_name_parts is not None:
+        script_type = 'R'
+        if verbose:
+          print("Found Repeatable file " + file_full_path)
+      elif always_script_name_parts is not None:
+        script_type = 'A'
+        if verbose:
+          print("Found Always file " + file_full_path)
+      else:
+        if verbose:
+          print("Ignoring non-change file " + file_full_path)
+        continue
+
+      # script name is the filename without any jinja extension
+      (file_part, extension_part) = os.path.splitext(file_name)
+      if extension_part.upper() == ".JINJA":
+        script_name = file_part
+      else:
+        script_name = file_name
+
+      # Add this script to our dictionary (as nested dictionary)
+      script = dict()
+      script['script_name'] = script_name
+      script['script_full_path'] = file_full_path
+      script['script_type'] = script_type
+      script['script_version'] = '' if script_type in ['R', 'A'] else script_name_parts.group(2)
+      if script_type == 'R':
+        script['script_description'] = repeatable_script_name_parts.group(2).replace('_', ' ').capitalize()
+      elif script_type == 'A':
+        script['script_description'] = always_script_name_parts.group(2).replace('_', ' ').capitalize()
+      else:
+        script['script_description'] = script_name_parts.group(3).replace('_', ' ').capitalize()
+
+      # Throw an error if the script_name already exists
+      if script_name in all_files:
+        raise ValueError( _err_dup_scripts.format(first_path=all_files[script_name]['script_full_path'], **script))
+
+      all_files[script_name] = script
+
+      # Throw an error if the same version exists more than once
+      if script_type == 'V':
+        if script['script_version'] in all_versions:
+          raise ValueError(_err_dup_scripts_version.format(**script))
+        all_versions.append(script['script_version'])
+
+  return all_files
+
+def get_change_history_table_details(change_history_table):
+  # Start with the global defaults
+  details = dict()
+  details['database_name'] = _metadata_database_name
+  details['schema_name'] = _metadata_schema_name
+  details['table_name'] = _metadata_table_name
+
+  # Then override the defaults if requested. The name could be in one, two or three part notation.
+  if change_history_table is not None:
+    table_name_parts = change_history_table.strip().split('.')
+    if len(table_name_parts) == 1:
+      details['table_name'] = table_name_parts[0]
+    elif len(table_name_parts) == 2:
+      details['table_name'] = table_name_parts[1]
+      details['schema_name'] = table_name_parts[0]
+    elif len(table_name_parts) == 3:
+      details['table_name'] = table_name_parts[2]
+      details['schema_name'] = table_name_parts[1]
+      details['database_name'] = table_name_parts[0]
+    else:
+      raise ValueError(_err_invalid_cht % change_history_table)
+  #if the object name does not include '"' raise to upper case on return
+  return {k:v if '"' in v else v.upper() for (k,v) in details.items()}
+
+def extract_config_secrets(config: Dict[str, Any]) -> Set[str]:
+  """
+  Extracts all secret values from the vars attributes in config
+  """
+
+  # defined as an inner/ nested function to provide encapsulation
+  def inner_extract_dictionary_secrets(dictionary: Dict[str, Any], child_of_secrets: bool = False) -> Set[str]:
+    """
+    Considers any key with the word secret in the name as a secret or
+    all values as secrets if a child of a key named secrets.
+    """
+    extracted_secrets: Set[str] = set()
+
+    if dictionary:
+      for (key, value) in dictionary.items():
+        if isinstance(value, dict):
+          if key == "secrets":
+            extracted_secrets = extracted_secrets | inner_extract_dictionary_secrets(value, True)
+          else :
+            extracted_secrets = extracted_secrets | inner_extract_dictionary_secrets(value, child_of_secrets)
+        elif child_of_secrets or "SECRET" in key.upper():
+          extracted_secrets.add(value.strip())
+    return extracted_secrets
+
+  extracted = set()
+
+  if config:
+    if "vars" in config:
+      extracted = inner_extract_dictionary_secrets(config["vars"])
+  return extracted
+
+def main(argv=sys.argv):
+  parser = argparse.ArgumentParser(prog = 'schemachange', description = 'Apply schema changes to a Snowflake account. Full readme at https://github.com/Snowflake-Labs/schemachange', formatter_class = argparse.RawTextHelpFormatter)
+  subcommands = parser.add_subparsers(dest='subcommand')
+
+  parser_deploy = subcommands.add_parser("deploy")
+  parser_deploy.add_argument('--config-folder', type = str, default = '.', help = 'The folder to look in for the schemachange-config.yml file (the default is the current working directory)', required = False)
+  parser_deploy.add_argument('-f', '--root-folder', type = str, help = 'The root folder for the database change scripts', required = False)
+  parser_deploy.add_argument('-m', '--modules-folder', type = str, help = 'The modules folder for jinja macros and templates to be used across multiple scripts', required = False)
+  parser_deploy.add_argument('-a', '--snowflake-account', type = str, help = 'The name of the snowflake account (e.g. xy12345.east-us-2.azure)', required = False)
+  parser_deploy.add_argument('-u', '--snowflake-user', type = str, help = 'The name of the snowflake user', required = False)
+  parser_deploy.add_argument('-r', '--snowflake-role', type = str, help = 'The name of the default role to use', required = False)
+  parser_deploy.add_argument('-w', '--snowflake-warehouse', type = str, help = 'The name of the default warehouse to use. Can be overridden in the change scripts.', required = False)
+  parser_deploy.add_argument('-d', '--snowflake-database', type = str, help = 'The name of the default database to use. Can be overridden in the change scripts.', required = False)
+  parser_deploy.add_argument('-s', '--snowflake-schema', type = str, help = 'The name of the default schema to use. Can be overridden in the change scripts.', required = False)
+  parser_deploy.add_argument('-c', '--change-history-table', type = str, help = 'Used to override the default name of the change history table (the default is METADATA.SCHEMACHANGE.CHANGE_HISTORY)', required = False)
+  parser_deploy.add_argument('-b', '--batch_migration_count', type=str, help='Used to override default batch size for repeatable migration operations. Default is set to 1.', required=False)
+  parser_deploy.add_argument('--vars', type = json.loads, help = 'Define values for the variables to replaced in change scripts, given in JSON format (e.g. {"variable1": "value1", "variable2": "value2"})', required = False)
+  parser_deploy.add_argument('--create-change-history-table', action='store_true', help = 'Create the change history schema and table, if they do not exist (the default is False)', required = False)
+  parser_deploy.add_argument('-ac', '--autocommit', action='store_true', help = 'Enable autocommit feature for DML commands (the default is False)', required = False)
+  parser_deploy.add_argument('-v','--verbose', action='store_true', help = 'Display verbose debugging details during execution (the default is False)', required = False)
+  parser_deploy.add_argument('--dry-run', action='store_true', help = 'Run schemachange in dry run mode (the default is False)', required = False)
+  parser_deploy.add_argument('--query-tag', type = str, help = 'The string to add to the Snowflake QUERY_TAG session value for each query executed', required = False)
+  parser_deploy.add_argument('--oauth-config', type = json.loads, help = 'Define values for the variables to Make Oauth Token requests  (e.g. {"token-provider-url": "https//...", "token-request-payload": {"client_id": "GUID_xyz",...},... })', required = False)
+   # TODO test CLI passing of args
+
+  parser_render = subcommands.add_parser('render', description="Renders a script to the console, used to check and verify jinja output from scripts.")
+  parser_render.add_argument('--config-folder', type = str, default = '.', help = 'The folder to look in for the schemachange-config.yml file (the default is the current working directory)', required = False)
+  parser_render.add_argument('-f', '--root-folder', type = str, help = 'The root folder for the database change scripts', required = False)
+  parser_render.add_argument('-m', '--modules-folder', type = str, help = 'The modules folder for jinja macros and templates to be used across multiple scripts', required = False)
+  parser_render.add_argument('--vars', type = json.loads, help = 'Define values for the variables to replaced in change scripts, given in JSON format (e.g. {"variable1": "value1", "variable2": "value2"})', required = False)
+  parser_render.add_argument('-v', '--verbose', action='store_true', help = 'Display verbose debugging details during execution (the default is False)', required = False)
+  parser_render.add_argument('script', type = str, help = 'The script to render')
+
+  # The original parameters did not support subcommands. Check if a subcommand has been supplied
+  # if not default to deploy to match original behaviour.
+  args = argv[1:]
+  if len(args) == 0 or not any(subcommand in args[0].upper() for subcommand in ["DEPLOY", "RENDER"]):
+    args = ["deploy"] + args
+
+  args = parser.parse_args(args)
+
+  print("schemachange version: %s" % _schemachange_version)
+
+  # First get the config values
+  config_file_path = os.path.join(args.config_folder, _config_file_name)
+
+  # Retreive argparser attributes as dictionary
+  schemachange_args = args.__dict__
+  schemachange_args['config_file_path'] = config_file_path
+
+  #nullify expected null values for render.
+  if args.subcommand == 'render':
+    renderoveride = {"snowflake_account":None,"snowflake_user":None,"snowflake_role":None, \
+      "snowflake_warehouse":None,"snowflake_database":None,"change_history_table":None, \
+      "snowflake_schema":None,"create_change_history_table":None,"autocommit":None, \
+      "dry_run":None,"query_tag":None,"oauth_config":None }
+    schemachange_args.update(renderoveride)
+  config = get_schemachange_config(**schemachange_args)
+
+  # setup a secret manager and assign to global scope
+  sm = SecretManager()
+  SecretManager.set_global_manager(sm)
+  # Extract all secrets for --vars
+  sm.add_range(extract_config_secrets(config))
+
+  # Then log some details
+  print("Using root folder %s" % config['root_folder'])
+  if config['modules_folder']:
+    print("Using Jinja modules folder %s" % config['modules_folder'])
+
+  # pretty print the variables in yaml style
+  if config['vars'] == {}:
+    print("Using variables: {}")
+  else:
+    print("Using variables:")
+    print(textwrap.indent( \
+      SecretManager.global_redact(yaml.dump( \
+        config['vars'], \
+        sort_keys=False, \
+        default_flow_style=False)), prefix = "  "))
+
+  # Finally, execute the command
+  if args.subcommand == 'render':
+    render_command(config, args.script)
+  else:
+    deploy_command(config)
+
+if __name__ == "__main__":
+  main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Jinja2~=3.0
 pandas~=1.3
 PyYAML~=6.0
-snowflake-connector-python>=2.8,<4.0
+snowflake-connector-python[pandas]>=2.8,<4.0


### PR DESCRIPTION
Add in repeatable migration batching process. This allows for repeatable migrations to be batched together to speed up deployment. The number of migrations batched together can be controlled via the config file and params. In the event of a failure in one of the batched repeatable migrations the repeatable migrations will be retried until the affected migration is found.