### PR TITLE
Add support for Jinja environment options in schemachange configuration.

### DIFF
--- a/tests/test_get_schemachange_config.py
+++ b/tests/test_get_schemachange_config.py
@@ -1,0 +1,48 @@
+import pathlib
+
+import pytest
+
+from schemachange.cli import get_schemachange_config
+
+
+def test_get_schemachange_config__using_restricted_jinja_environment_settings_set_should_raise_exception(
+            tmp_path: pathlib.Path):
+  # Test that we do not allow the user to set Jinja environment variables that would
+  # conflict with the default settings
+  config_contents = """
+config-version: 1.1
+vars:
+  database_name: SCHEMACHANGE_DEMO_JINJA
+jinja:
+  autoescape: True
+  undefined: ""
+  extensions: []
+  loader: null
+"""
+  config_file = tmp_path / "schemachange-config.yml"
+  config_file.write_text(config_contents)
+  with pytest.raises(ValueError) as e:
+    config = get_schemachange_config(str(config_file), None, None, None,
+                       None, None, None, None,
+                     None,None, None, False,
+                          False, None,True, None, None)
+  assert str(e.value) == "Restricted Jinja environment settings provided: autoescape, extensions, loader, undefined"
+
+
+def test_get_schemachange_config__using_invalid_jinja_environment_should_raise_exception(tmp_path: pathlib.Path):
+  # Test that Jinja environment is valid if set
+  config_contents = """
+config-version: 1.1
+vars:
+  database_name: SCHEMACHANGE_DEMO_JINJA
+jinja: test
+"""
+  config_file = tmp_path / "schemachange-config.yml"
+  config_file.write_text(config_contents)
+
+  with pytest.raises(ValueError) as e:
+    config = get_schemachange_config(str(config_file), None, None, None,
+                        None, None, None, None,
+                     None,None, None, False,
+                          False, False,True, None, None)
+  assert str(e.value) == "jinja did not parse correctly, please check its configuration"

--- a/tests/test_jinja_env_config_template.py
+++ b/tests/test_jinja_env_config_template.py
@@ -1,0 +1,21 @@
+from jinja2 import DictLoader
+from schemachange.cli import JinjaTemplateProcessor, _jinja_env_defaults
+
+
+def test_jinja_environment_variables_set():
+    jinja_env_args = {"trim_blocks": True,
+                      "lstrip_blocks": True,
+                      "block_start_string": "<%",
+                      "block_end_string": "%>",
+                      "variable_start_string": "[[",
+                      "variable_end_string": "]]"}
+    processor = JinjaTemplateProcessor("", None, jinja_env_args)
+    templates = {"test.sql": """<% for item in items %>[[ item ]] <% endfor %>"""}
+    expected_env_args = set(jinja_env_args.keys()) | _jinja_env_defaults
+    unexpected_env_args = expected_env_args ^ set(processor._env_args.keys())
+    # Ensure all Jinja environment variables are set including the defaults
+    assert len(unexpected_env_args) == 0, f"Unexpected jinja environment variables set: {unexpected_env_args}"
+    processor.override_loader(DictLoader(templates))
+    # Test that Jinja environment variables are taking effect
+    result = processor.render("test.sql", {"items": ['a', 'b', 'c']}, True)
+    assert result == 'a b c', f"Unexpected result: {result}"


### PR DESCRIPTION
Added ability to configure some [Jinja Environment](https://jinja.palletsprojects.com/en/3.0.x/api/#high-level-api) settings within the schemachange configuration via a new "jinja" section.   This section would allow users to customize several parsing and rendering options in Jinja like `trim_blocks` `lstrip_blocks`, `block_start_string`,  `block_end_string`, `variable_start_string`, `variable_end_string`, but disallows changing settings which could impact the behavior of schemachange like `undefined,` `loader`, `enable_async`.