### PR TITLE
Redact multiline secrets

### DIFF
--- a/schemachange/cli.py
+++ b/schemachange/cli.py
@@ -185,7 +185,7 @@ class SecretManager:
     redacted = context
     if redacted:
       for secret in self.__secrets:
-        redacted = redacted.replace(secret, "*" * len(secret))
+        redacted = redacted.replace(secret, '\n'.join(["*" * len(l) for l in secret.split('\n')]))
     return redacted
 
 

--- a/tests/test_SecretManager.py
+++ b/tests/test_SecretManager.py
@@ -22,6 +22,13 @@ def test_SecretManager_given_secrets_when_redact_then_return_redacted_value():
     assert result == "Hello *****!"
 
 
+def test_SecretManager_given_multiline_secrets_when_redact_then_return_redacted_value():
+    sm = SecretManager()
+    sm.add("Hello\nworld")
+    result = sm.redact("Hello\nworld!")
+    assert result == "***********!"
+
+
 def test_SecretManager_given_secrets_when_clear_then_should_hold_zero_secrets():
     sm = SecretManager()
     sm.add("world")

--- a/tests/test_SecretManager.py
+++ b/tests/test_SecretManager.py
@@ -26,7 +26,7 @@ def test_SecretManager_given_multiline_secrets_when_redact_then_return_redacted_
     sm = SecretManager()
     sm.add("Hello\nworld")
     result = sm.redact("Hello\nworld!")
-    assert result == "***********!"
+    assert result == "*****\n*****!"
 
 
 def test_SecretManager_given_secrets_when_clear_then_should_hold_zero_secrets():

--- a/tests/test_extract_config_secrets.py
+++ b/tests/test_extract_config_secrets.py
@@ -52,3 +52,12 @@ def test_extract_config_secrets_given__vars_with_same_secret_twice_then_only_ext
 
     assert len(results) == 1
     assert "SECRET_VALUE" in results
+
+
+def test_extract_config_secrets_given__vars_with_multiline_secret_then_preserve_newlines():
+    config = {"vars": {"secrets" : {"database_name": "SECRET\nVALUE"} } }
+
+    results = extract_config_secrets(config)
+
+    assert len(results) == 1
+    assert "SECRET\nVALUE" in results

--- a/tests/test_redact_config_vars.py
+++ b/tests/test_redact_config_vars.py
@@ -1,0 +1,61 @@
+import pytest
+from schemachange.cli import redact_config_vars, SecretManager
+
+
+def test_redact_config_vars_given_secret_val_should_redact_it():
+    config_vars = {'secret' : 'secret_val'}
+    sm = SecretManager()
+    SecretManager.set_global_manager(sm)
+    sm.add('secret_val')
+    results = redact_config_vars(config_vars)
+    redacted = {'secret' : '**********'}
+    assert results == redacted
+
+
+def test_redact_config_vars_given_number_like_secret_should_redact_it():
+    config_vars = {'secret' : '123'}
+    sm = SecretManager()
+    SecretManager.set_global_manager(sm)
+    sm.add('123')
+    results = redact_config_vars(config_vars)
+    redacted = {'secret' : '***'}
+    assert results == redacted
+
+
+def test_redact_config_vars_given_number_like_secret_should_redact_it_but_not_an_actual_number():
+    config_vars = {'secret' : '123', 'public': 123}
+    sm = SecretManager()
+    SecretManager.set_global_manager(sm)
+    sm.add('123')
+    results = redact_config_vars(config_vars)
+    redacted = {'secret' : '***', 'public': 123}
+    assert results == redacted
+
+
+def test_redact_config_vars_given_secret_should_redact_it_in_any_string_it_finds_it():
+    config_vars = {'secrets': {'password' : 'hi'}, 'jdbc': 'jdbc:mysql://127.0.0.1;user=john;password=hi'}
+    sm = SecretManager()
+    SecretManager.set_global_manager(sm)
+    sm.add('hi')
+    results = redact_config_vars(config_vars)
+    redacted = {'secrets': {'password' : '**'}, 'jdbc': 'jdbc:mysql://127.0.0.1;user=john;password=**'}
+    assert results == redacted
+
+
+def test_redact_config_vars_given_secret_should_redact_it_in_any_string_it_finds_it_even_in_lists():
+    # At the moment, it's not documented that we could specify lists as values for variables, but,
+    # nothing is preventing people from trying things. Just in case, redact_config_vars is
+    # able to also redact strings inside lists. That's why this test is here.
+    # Finally note that tuples are not scanned, just making the point that this redact function cannot
+    # do everything; YAML deserialises lists as Python lists, not tuples, so we have no use case for tuples.
+    config_vars = {'secrets': {'password' : 'hi'}, 'jdbc': 'jdbc:mysql://127.0.0.1',
+                   'accounts': [{'user': 'john', 'password': '**'}], 'greetings': ['hi', 'hello'], 'greetings_tuple': ('hi',)}
+    sm = SecretManager()
+    SecretManager.set_global_manager(sm)
+    sm.add('hi')
+    results = redact_config_vars(config_vars)
+    redacted = {'secrets': {'password' : '**'}, 'jdbc': 'jdbc:mysql://127.0.0.1',
+                'accounts': [{'user': 'john', 'password': '**'}], 'greetings': ['**', 'hello'], 'greetings_tuple': ('hi',)}
+    assert results == redacted
+
+


### PR DESCRIPTION
**Problem**
When given a multi-line secret in the schemachange-config YAML, it would not be redacted, because just before calling `SecretManager.global_redact`, the config vars section would be serialised as YAML, adding leading whitespaces to the multiline secret

**Proposed solution**
Recurse over the config vars section, and redact all strings in it, and only then serialise as YAML.  When redacting multiline secrets, preserve newlines.

**Minor edits added in**
- The method that was extracting secrets would crash if the value was of a type that did not have the `strip()` method. Added an explicit raise of a ValueError if a secret is not of type `str`
- Added tests for added functionality

**Notes**
For redacting in SQL queries nothing was changed, as indenting while rendering Jinja templates is under control of the user of schemachange.
