### PR TITLE
fix incorrect oauth example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ dry-run: false
 query-tag: 'QUERY_TAG'
 
 # Information for Oauth token requests
-oauthconfig:
+oauth_config:
   # url Where token request are posted to
   token-provider-url: 'https://login.microsoftonline.com/{{ env_var('AZURE_ORG_GUID', 'default') }}/oauth2/v2.0/token'
   # name of Json entity returned by request


### PR DESCRIPTION
The definition of oauth_config in the schemachange-config.yml example within README.md is incorrect.  This causes anyone who copies the example to have issues with oauth authentication until they discover and fix this typo.  This change fixes it in the readme.  See issue #283 

Fixes #283 