### PR TITLE
fix: remove unused password attribute when authenticating via externalbrowser

### DIFF
--- a/schemachange/session/Credential.py
+++ b/schemachange/session/Credential.py
@@ -40,7 +40,6 @@ class PrivateKeyCredential(Credential):
 @dataclasses.dataclass(kw_only=True, frozen=True)
 class ExternalBrowserCredential(Credential):
     authenticator: Literal["externalbrowser"] = "externalbrowser"
-    password: str | None = None
 
 
 @dataclasses.dataclass(kw_only=True, frozen=True)

--- a/tests/session/test_SnowflakeSession.py
+++ b/tests/session/test_SnowflakeSession.py
@@ -12,7 +12,7 @@ from schemachange.session.SnowflakeSession import SnowflakeSession
 
 @pytest.fixture
 def session() -> SnowflakeSession:
-    credential = ExternalBrowserCredential(password="password")
+    credential = ExternalBrowserCredential()
     change_history_table = ChangeHistoryTable()
     logger = structlog.testing.CapturingLogger()
 


### PR DESCRIPTION
Closes bug [Bug 289](https://github.com/Snowflake-Labs/schemachange/issues/289)