### PR TITLE
fix(docs): typo on Private Key Authentication & connections.toml key

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,8 +338,8 @@ your Okta administrator for more information._
 
 ### Private Key Authentication
 
-External browser authentication can be selected by supplying `snowflake_jwt` as your authenticator. The filepath to a
-Snowflake user-encrypted private key must be supplied as `private-key` in the [connections.toml](#connectionstoml-file)
+Private key authentication can be selected by supplying `snowflake_jwt` as your authenticator. The filepath to a
+Snowflake user-encrypted private key must be supplied as `private_key_file` in the [connections.toml](#connectionstoml-file)
 file. If the private key file is password protected, supply the password as `private_key_file_pwd` in
 the [connections.toml](#connectionstoml-file) file. If the variable is not set, the Snowflake Python connector will
 assume the private key is not encrypted.


### PR DESCRIPTION
Fix some obvious typos.

The `private_key_*` is confusing as the connections.toml prefers something else but this tool requires `private_key_file`.