### PR TITLE
output skipped executions in dry run

### DIFF
--- a/schemachange/session/SnowflakeSession.py
+++ b/schemachange/session/SnowflakeSession.py
@@ -151,7 +151,7 @@ class SnowflakeSession:
     def create_change_history_schema(self, dry_run: bool) -> None:
         query = f"CREATE SCHEMA IF NOT EXISTS {self.change_history_table.fully_qualified_schema_name}"
         if dry_run:
-            self.logger.debug(
+            self.logger.info(
                 "Running in dry-run mode. Skipping execution.",
                 query=indent(dedent(query), prefix="\t"),
             )
@@ -173,7 +173,7 @@ class SnowflakeSession:
             )
         """
         if dry_run:
-            self.logger.debug(
+            self.logger.info(
                 "Running in dry-run mode. Skipping execution.",
                 query=indent(dedent(query), prefix="\t"),
             )
@@ -308,7 +308,7 @@ class SnowflakeSession:
         logger: structlog.BoundLogger,
     ) -> None:
         if dry_run:
-            logger.debug("Running in dry-run mode. Skipping execution")
+            logger.info("Running in dry-run mode. Skipping execution")
             return
         logger.info("Applying change script")
         # Define a few other change related variables


### PR DESCRIPTION
This was a change in behavior with 4.0.0 - changing back to outputting the skipped scripts when doing a dry run. Confirmed that it worked:

```
$ pip install -e ../schemachange/
$ schemachange --config-folder config/dev -f . --dry-run    
...
2025-01-22T04:21:50.176530Z [info     ] Running in dry-run mode. Skipping execution a_script_name=R__4_Create_Service_Accts.sql script_version=N/A
2025-01-22T04:21:50.250614Z [info     ] Running in dry-run mode. Skipping execution a_script_name=R__Network_Policies.sql script_version=N/A
```