### PR TITLE
Restore ability to define password in environment variable

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,8 +31,8 @@ repos:
         args: [ --fix ]
       # Run the formatter.
       - id: ruff-format
-  - repo: git@github.com:GitGuardian/ggshield.git
-    rev: v1.28.0
+  - repo: https://github.com/gitguardian/ggshield
+    rev: v1.36.0
     hooks:
       - id: ggshield
         language_version: python3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,11 @@ All notable changes to this project will be documented in this file.
 
 *The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).*
 
-## [4.0.0] - TBD
+## [4.0.1] - TBD
+### Changed
+- Added back the ability to pass the Snowflake password in the `SNOWFLAKE_PASSWORD` environment variable.
+
+## [4.0.0] - 2025-01-06
 ### Added
 - Use of `structlog~=24.1.0` for standard log outputs
 - Verified Schemachange against Python 3.12

--- a/schemachange/cli.py
+++ b/schemachange/cli.py
@@ -13,7 +13,7 @@ from schemachange.session.SnowflakeSession import SnowflakeSession
 
 # region Global Variables
 # metadata
-SCHEMACHANGE_VERSION = "4.0.0"
+SCHEMACHANGE_VERSION = "4.0.1"
 SNOWFLAKE_APPLICATION_NAME = "schemachange"
 module_logger = structlog.getLogger(__name__)
 

--- a/schemachange/config/DeployConfig.py
+++ b/schemachange/config/DeployConfig.py
@@ -8,6 +8,7 @@ from schemachange.config.BaseConfig import BaseConfig
 from schemachange.config.ChangeHistoryTable import ChangeHistoryTable
 from schemachange.config.utils import (
     get_snowflake_identifier_string,
+    get_snowflake_password,
 )
 
 
@@ -87,9 +88,9 @@ class DeployConfig(BaseConfig):
             "query_tag": self.query_tag,
         }
 
-        # TODO: Discuss the need for check for snowflake password before passing the session
-        # kwargs to open a snowflake session
-        # snowflake_password = get_snowflake_password()
-        # if snowflake_password is not None and snowflake_password:
-        #    session_kwargs["password"] = snowflake_password
+        # If the user supplied the password in the environment variable, add it to the session config
+        snowflake_password = get_snowflake_password()
+        if snowflake_password is not None and snowflake_password:
+            session_kwargs["password"] = snowflake_password
+
         return {k: v for k, v in session_kwargs.items() if v is not None}

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = schemachange
-version = 4.0.0
+version = 4.0.1
 description = A Database Change Management tool for Snowflake
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/tests/test_cli_misc.py
+++ b/tests/test_cli_misc.py
@@ -9,7 +9,7 @@ from schemachange.deploy import alphanum_convert, get_alphanum_key, sorted_alpha
 
 
 def test_cli_given__schemachange_version_change_updated_in_setup_config_file():
-    assert SCHEMACHANGE_VERSION == "4.0.0"
+    assert SCHEMACHANGE_VERSION == "4.0.1"
 
 
 def test_cli_given__constants_exist():


### PR DESCRIPTION
This change will restore the ability for users to define their Snowflake password using the `SNOWFLAKE_PASSWORD` environment variable.