### PR TITLE
feat: support private key env.

### DIFF
--- a/schemachange/config/DeployConfig.py
+++ b/schemachange/config/DeployConfig.py
@@ -9,6 +9,7 @@ from schemachange.config.ChangeHistoryTable import ChangeHistoryTable
 from schemachange.config.utils import (
     get_snowflake_identifier_string,
     get_snowflake_password,
+    get_snowflake_private_key,
 )
 
 
@@ -92,5 +93,12 @@ class DeployConfig(BaseConfig):
         snowflake_password = get_snowflake_password()
         if snowflake_password is not None and snowflake_password:
             session_kwargs["password"] = snowflake_password
+
+        private_key_path, private_key_passphrase = get_snowflake_private_key()
+        if private_key_path:
+            session_kwargs["private_key_path"] = private_key_path
+
+        if private_key_passphrase:
+            session_kwargs["private_key_passphrase"] = private_key_passphrase
 
         return {k: v for k, v in session_kwargs.items() if v is not None}

--- a/schemachange/config/utils.py
+++ b/schemachange/config/utils.py
@@ -161,3 +161,9 @@ def get_snowflake_password() -> str | None:
         return snowsql_pwd
     else:
         return None
+
+
+def get_snowflake_private_key() -> tuple[str | None, str | None]:
+    private_key_path = os.getenv("SNOWFLAKE_PRIVATE_KEY_PATH")
+    private_key_passphrase = os.getenv("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE")
+    return private_key_path, private_key_passphrase

--- a/schemachange/session/SnowflakeSession.py
+++ b/schemachange/session/SnowflakeSession.py
@@ -10,7 +10,7 @@ import structlog
 
 from schemachange.config.ChangeHistoryTable import ChangeHistoryTable
 from schemachange.config.utils import get_snowflake_identifier_string
-from schemachange.session.Script import VersionedScript, RepeatableScript, AlwaysScript
+from schemachange.session.Script import AlwaysScript, RepeatableScript, VersionedScript
 
 
 class SnowflakeSession:
@@ -64,7 +64,10 @@ class SnowflakeSession:
             "role": role,  # TODO: Remove when connections.toml is enforced
             "warehouse": warehouse,  # TODO: Remove when connections.toml is enforced
             "private_key_file": kwargs.get(
-                "private_key_path"
+                "private_key_file"
+            ),  # TODO: Remove when connections.toml is enforced
+            "private_key_file_pwd": kwargs.get(
+                "private_key_file_pwd"
             ),  # TODO: Remove when connections.toml is enforced
             "token": kwargs.get(
                 "oauth_token"


### PR DESCRIPTION
After updating from 3.7.0 to 4.0.1, authentication by keypath now gives an error.

This PR restores the implementation that recognizes `SNOWFLAKE_PRIVATE_KEY_PATH`, `SNOWFLAKE_PRIVATE_KEY_PASSPHRASE`.

The GitHub Action workflow we used is as follows:

```yaml
jobs:
  schemachange:
      - ...
      - name: Execute Snowflake migration
        env:
          SNOWFLAKE_ACCOUNT: ${{ secrets.SNOWFLAKE_ACCOUNT }}
          SNOWFLAKE_PRIVATE_KEY_PATH: ${{ secrets.SNOWFLAKE_PRIVATE_KEY_PATH }}
          SNOWFLAKE_PRIVATE_KEY_PASSPHRASE: ${{ secrets.SCHEMA_CHANGE_SNOWFLAKE_PRIVATE_KEY_PASSPHRASE }}
        run: |
          echo "${{ secrets.SCHEMA_CHANGE_SNOWFLAKE_PRIVATE_KEY }}" > ${{ env.SNOWFLAKE_PRIVATE_KEY_PATH }}
          make migration-snowflake
          rm -f ${{ env.SNOWFLAKE_PRIVATE_KEY_PATH }}
```

Since Snowflake is discontinuing single-factor password authentication, my team has moved to Key/Pair authentication.