### PR TITLE
feat: add py.typed marker for mypy users

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,3 +40,6 @@ dev =
     pre-commit
     pyfakefs
     pytest
+
+[options.package_data]
+schemachange = py.typed


### PR DESCRIPTION
This lib is pretty well typed, but MyPy doesn't know to look for the types by default. Adding a py.typed file will tell MyPy to look at the type hints in the package directly. It's a pretty simple add for some big gains!

https://mypy.readthedocs.io/en/stable/installed_packages.html#creating-pep-561-compatible-packages