### PR TITLE
chore(release): bump version to 4.2.0 and update CHANGELOG with confi…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to this project will be documented in this file.
 
 *The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).*
 
+## [4.2.0] - 2025-08-28
+### Added
+- Added validation for unknown configuration keys with warning messages instead of errors for better backward and sideways compatibility
+
+### Fixed
+- Fixed YAML configuration validation to show warnings for unknown keys instead of throwing TypeError exceptions
+
 ## [4.1.0] - 2025-08-05
 ### Added
 - Added flag `--error-on-ignored-versioned-migration` to throw an error when versioned migrations are ignored due to being out of order (#287 by @zanebclark)

--- a/README.md
+++ b/README.md
@@ -436,6 +436,21 @@ The YAML config file supports the jinja templating language and has a custom fun
 variables. Jinja variables are unavailable and not yet loaded since they are supplied by the YAML file. Customisation of
 the YAML file can only happen through values passed via environment variables.
 
+#### Configuration Validation
+
+Schemachange validates YAML configuration files and provides helpful feedback for configuration issues:
+
+**Unknown Keys**: If your configuration contains keys that are not recognized by schemachange, you will see warning messages like:
+```
+Unknown configuration keys found and will be ignored: unknown_key, another_unknown_key
+```
+
+This behavior ensures:
+- **Backward compatibility**: Existing configurations continue to work
+- **Sideways compatibility**: Tools that overlay schemachange can add custom keys without conflicts
+- **Clear feedback**: Users are informed about ignored configuration options
+- **No errors**: Unknown keys are filtered out rather than causing deployment failures
+
 ##### env_var
 
 Provides access to environmental variables. The function can be used two different ways.

--- a/schemachange/cli.py
+++ b/schemachange/cli.py
@@ -13,7 +13,7 @@ from schemachange.session.SnowflakeSession import SnowflakeSession
 
 # region Global Variables
 # metadata
-SCHEMACHANGE_VERSION = "4.0.1"
+SCHEMACHANGE_VERSION = "4.2.0"
 SNOWFLAKE_APPLICATION_NAME = "schemachange"
 module_logger = structlog.getLogger(__name__)
 

--- a/schemachange/config/BaseConfig.py
+++ b/schemachange/config/BaseConfig.py
@@ -47,6 +47,19 @@ class BaseConfig(ABC):
                 "config_vars did not parse correctly, please check its configuration"
             ) from e
 
+        # Get the field names from the dataclass to validate against
+        field_names = {field.name for field in dataclasses.fields(cls)}
+
+        # Check for unknown keys and warn about them
+        unknown_keys = set(kwargs.keys()) - field_names
+        if unknown_keys:
+            unknown_keys_str = ", ".join(sorted(unknown_keys))
+            logger.warning(
+                f"Unknown configuration keys found and will be ignored: {unknown_keys_str}"
+            )
+            # Filter out unknown keys to prevent TypeError
+            kwargs = {k: v for k, v in kwargs.items() if k in field_names}
+
         return cls(
             subcommand=subcommand,
             config_file_path=config_file_path,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = schemachange
-version = 4.0.1
+version = 4.2.0
 description = A Database Change Management tool for Snowflake
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/tests/test_cli_misc.py
+++ b/tests/test_cli_misc.py
@@ -9,7 +9,7 @@ from schemachange.deploy import alphanum_convert, get_alphanum_key, sorted_alpha
 
 
 def test_cli_given__schemachange_version_change_updated_in_setup_config_file():
-    assert SCHEMACHANGE_VERSION == "4.0.1"
+    assert SCHEMACHANGE_VERSION == "4.2.0"
 
 
 def test_cli_given__constants_exist():


### PR DESCRIPTION
This pull request introduces a new configuration validation feature and updates the project version to 4.2.0. The main improvement is that unknown keys in YAML configuration files now trigger warnings instead of errors, improving compatibility and user experience. Documentation has been updated to reflect these changes.

Configuration validation improvements:

* Added logic to `schemachange/config/BaseConfig.py` to detect unknown configuration keys in YAML configs, log a warning message listing them, and filter them out to prevent runtime errors.
* Updated the `README.md` to document the new behavior for unknown configuration keys, explaining the rationale and benefits for backward and sideways compatibility.

Version updates:

* Bumped the version number to 4.2.0 in `setup.cfg`, `schemachange/cli.py`, and corresponding test assertions in `tests/test_cli_misc.py`. [[1]](diffhunk://#diff-fa602a8a75dc9dcc92261bac5f533c2a85e34fcceaff63b3a3a81d9acde2fc52L3-R3) [[2]](diffhunk://#diff-f7ef5e4cb20a32bace61ec57979bcbb18843f0bfc612e8b585b603d5df749aabL16-R16) [[3]](diffhunk://#diff-1308764af3c1a5f35bcc0a90462b2625802596cc0f5024f9ce704fdff7d42b7eL12-R12)
* Added a new entry in `CHANGELOG.md` for version 4.2.0, summarizing the added validation and bug fix for configuration key handling.