### PR TITLE
Fix session parameters from connections.toml being ignored

### DIFF
--- a/tests/session/test_session_parameters.py
+++ b/tests/session/test_session_parameters.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+import structlog
+
+from schemachange.config.ChangeHistoryTable import ChangeHistoryTable
+from schemachange.session.SnowflakeSession import SnowflakeSession
+
+
+@pytest.fixture
+def mock_snowflake_connect():
+    with mock.patch("snowflake.connector.connect") as mock_connect:
+        mock_con = mock.MagicMock()
+        mock_con._session_parameters = {
+            "QUOTED_IDENTIFIERS_IGNORE_CASE": False,
+            "QUERY_TAG": "existing_tag"
+        }
+        mock_connect.return_value = mock_con
+        yield mock_connect
+
+
+def test_session_parameters_from_toml(mock_snowflake_connect):
+    """Test that session parameters from connections.toml are respected and merged with QUERY_TAG"""
+    change_history_table = ChangeHistoryTable()
+    logger = structlog.testing.CapturingLogger()
+
+    with mock.patch("schemachange.session.SnowflakeSession.get_snowflake_identifier_string"):
+        session = SnowflakeSession(
+            user="user",
+            account="account",
+            role="role",
+            warehouse="warehouse", 
+            schemachange_version="3.6.1.dev",
+            application="schemachange",
+            change_history_table=change_history_table,
+            logger=logger,
+            connections_file_path="connections.toml",
+            connection_name="test_connection",
+            query_tag="custom_tag"
+        )
+
+        first_call_kwargs = mock_snowflake_connect.call_args_list[0][1]
+        assert first_call_kwargs["connections_file_path"] == "connections.toml"
+        assert first_call_kwargs["connection_name"] == "test_connection"
+        assert "session_parameters" not in first_call_kwargs
+
+        second_call_kwargs = mock_snowflake_connect.call_args_list[1][1]
+        assert second_call_kwargs["session_parameters"] == {
+            "QUOTED_IDENTIFIERS_IGNORE_CASE": False,
+            "QUERY_TAG": "existing_tag;schemachange 3.6.1.dev;custom_tag"
+        }


### PR DESCRIPTION
Fix #350

Previously, schemachange would ignore any session parameters defined in the connections.toml file because it was overwriting them with its own session parameters. This fix:

1. Preserves session parameters from connections.toml
2. Properly merges QUERY_TAG values (combining existing tags with schemachange's tag)
3. Maintains all other session parameters (e.g., QUOTED_IDENTIFIERS_IGNORE_CASE)

Example:
If your connections.toml has:
[STG]
session_parameters = { 
    QUOTED_IDENTIFIERS_IGNORE_CASE = false,
    QUERY_TAG = "my_tag"
}

The session will now:
- Keep QUOTED_IDENTIFIERS_IGNORE_CASE = false
- Set QUERY_TAG = "my_tag;schemachange <version>;custom_tag" (if custom_tag provided)

Changes made:
- Modified SnowflakeSession.py to read session parameters from connections.toml first
- Added proper session parameter merging logic
- Added test coverage in test_session_parameters.py