### PR TITLE
Resolve dry-run fails when version scripts exists and version table not exists yet

### DIFF
--- a/schemachange/session/SnowflakeSession.py
+++ b/schemachange/session/SnowflakeSession.py
@@ -219,7 +219,7 @@ class SnowflakeSession:
             dry_run=dry_run,
         )
         if not change_history_table_exists:
-            return None, None, None
+            return defaultdict(dict), None, None
 
         change_history, max_published_version = self.fetch_versioned_scripts()
         r_scripts_checksum = self.fetch_repeatable_scripts()


### PR DESCRIPTION
Resolves Snowflake-Labs/schemachange#326

Addresses issue

```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/root/.schema_change/lib/python3.12/site-packages/schemachange/cli.py", line 75, in <module>
    main()
  File "/root/.schema_change/lib/python3.12/site-packages/schemachange/cli.py", line 71, in main
    deploy(config=config, session=session)
  File "/root/.schema_change/lib/python3.12/site-packages/schemachange/deploy.py", line 102, in deploy
    script_metadata = versioned_scripts.get(script.name)
                      ^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'get'
```

Which occurs in dry-run mode when version scripts are being deployed and version table does not exists yet.


Instead of None, returns  empty dictionary `defaultdict(dict)` as change_history.