### PR TITLE
Fix missing colorama dependency on Windows after colorized output change

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "requests",
     "snowflake-connector-python>=2.8,<5.0",
     "structlog~=24.1.0",
+    "colorama; platform_system == 'Windows'",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary

PR #357 added support for disabling colored output via `NO_COLOR` and enabled colored logging by default. This introduced a hard runtime dependency on `colorama` when running on Windows, because structlog requires it when `colors=True`. However, `colorama` was not added to `pyproject.toml`, so it is **not automatically installed** by pip on Windows environments.

As a result, any Windows-based CI/CD pipeline installing schemachange via:

```bash
pip install schemachange
```

now fails with:

```
ConsoleRenderer with `colors=True` requires the colorama package installed
```

This PR fixes the packaging metadata by declaring `colorama` as a platform-specific dependency.

---

## Root Cause

* PR #357 added color support using structlog
* `ConsoleRenderer(colors=True)` now raises if `colorama` is missing on Windows
* `colorama` is not declared in `pyproject.toml`
* pip does not install it automatically
* Windows agents break even for simple installs / dry-runs

This is a packaging metadata issue, not a pipeline or user configuration issue.

---

## Fix

Add the appropriate marker dependency:

### `pyproject.toml` diff:

```diff
[project]
dependencies = [
       "snowflake-connector-python>=2.8,<5.0",
       "structlog~=24.1.0",
+    "colorama; platform_system == 'Windows'",
]
```

---

## Why platform-specific?

This matches Python packaging best practices and avoids installing colorama unnecessarily on Linux/macOS.

---

## Optional (Recommended) Future Work

A more resilient solution would fall back to non-color output if colorama is missing, instead of hard failing:

```python
try:
    import colorama
except ImportError:
    colors = False
```

That would prevent breakage even if metadata is incorrect.

---

## Impact

🟢 Fixes broken Windows CI/CD installers
🟢 No behavioral change for users on Linux/macOS
🟢 Packaging metadata becomes correct and compliant
