### PR TITLE
fix: re-introduce private_key_file_pwd in params for connection to snowflake, was removed from 4.0.1 to 4.1.0

### DIFF
--- a/schemachange/session/SnowflakeSession.py
+++ b/schemachange/session/SnowflakeSession.py
@@ -90,6 +90,7 @@ class SnowflakeSession:
             "private_key_file": kwargs.get(
                 "private_key_file"
             ),  # Already mapped from private_key_path in get_session_kwargs()
+            "private_key_file_pwd": kwargs.get("private_key_file_pwd"),
             "token": kwargs.get("token"),
             "password": kwargs.get("password"),
             "authenticator": kwargs.get("authenticator"),


### PR DESCRIPTION
Add private_key_file_pwd handling back to SnowflakeSession.

This pull request introduces a small update to the SnowflakeSession initialization logic. The change adds support for passing a private_key_file_pwd parameter when creating a session, allowing encrypted private key authentication to function again.

In 4.1.0 all connection parameters (from CLI, env, YAML, and connections.toml) are merged before SnowflakeSession is created, and DeployConfig.get_session_kwargs() already places both private_key_file and private_key_file_pwd in the kwargs handed to the session. 

However, the refactor that removed connection_name/connections_file_path from SnowflakeSession also rewrote the explicit_params dict that feeds snowflake.connector.connect(), and that new dict only forwarded private_key_file and the private_key_file_pwd entry was dropped. 

Because of that the connector now sees an encrypted key without its passphrase and fails with “Password was not given but private key is encrypted.”
Restoring private_key_file_pwd in SnowflakeSession’s connect_kwargs keeps the rest of the 4.1.0 refactor intact while making key‑pair authentication work again.


Will solve : https://github.com/Snowflake-Labs/schemachange/issues/394