### PR TITLE
Snowflake CLI integration and out of order execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,24 @@ All notable changes to this project will be documented in this file.
 
 *The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).*
 
-## [4.2.0] - TBD
+## [4.3.0] - TBD
+### Added
+- **CLI Migration Scripts (`.cli.yml`)**: Execute CLI commands as part of your deployment process. Deploy complex Snowflake objects like dbt projects or Snowpark functions using the Snowflake CLI (`snow`) directly from schemachange:
+  - Supports all script types: Versioned (`V`), Repeatable (`R`), and Always (`A`)
+  - YAML-based step definitions with command, args, working directory, and environment variables
+  - Jinja templating support via `.cli.yml.jinja` extension
+  - Full change history tracking with Success/Failed status
+- **Out-of-Order Execution (`--out-of-order`)**: Allow versioned scripts to be applied regardless of whether their version is older than the maximum applied version. Useful for parallel development workflows where branches merge in any order:
+  - CLI flag: `--out-of-order`
+  - Environment variable: `SCHEMACHANGE_OUT_OF_ORDER`
+  - YAML config: `out-of-order: true`
+- **Failed Script Logging**: Script execution failures are now recorded in the change history table with `STATUS = 'Failed'`, improving visibility and troubleshooting
+
+### Fixed
+- **Password from connections.toml not being passed to Snowflake connector**: The password parameter from `connections.toml` is now correctly passed through to the Snowflake connector. This fix enables proper password authentication when credentials are defined in `connections.toml`.
+
+
+## [4.2.0] - 2026-01-02
 ### Added
 - Validation for unknown configuration keys with warnings (#352 by @MACKAT05)
 - Support for snowflake-connector-python 4.x (#363)

--- a/demo/cli_demo/A__cli_test.cli.yml
+++ b/demo/cli_demo/A__cli_test.cli.yml
@@ -1,0 +1,14 @@
+steps:
+  - cli: snow
+    command: init
+    working_dir: .
+    description: "Test CLI"
+  - cli: snow
+    command: sql
+    args:
+      - "--connection"
+      - "defaultold"
+      - "--query"
+      - "SELECT 1"
+    working_dir: .
+    description: "Test CLI Query"

--- a/demo/cli_demo/A__cli_test.cli.yml
+++ b/demo/cli_demo/A__cli_test.cli.yml
@@ -3,12 +3,3 @@ steps:
     command: init
     working_dir: .
     description: "Test CLI"
-  - cli: snow
-    command: sql
-    args:
-      - "--connection"
-      - "defaultold"
-      - "--query"
-      - "SELECT 1"
-    working_dir: .
-    description: "Test CLI Query"

--- a/demo/cli_demo/R__test_cli.cli.yml
+++ b/demo/cli_demo/R__test_cli.cli.yml
@@ -1,0 +1,10 @@
+steps:
+  - cli: snow
+    command: sql
+    args:
+      - "--connection"
+      - "defaultold"
+      - "--query"
+      - "SELECT 1"
+    working_dir: .
+    description: "Test CLI Query"

--- a/demo/cli_demo/R__test_sql.sql
+++ b/demo/cli_demo/R__test_sql.sql
@@ -1,0 +1,1 @@
+SELECT 'FOO BAR';

--- a/demo/cli_demo/V1.0.0__deploy_test.cli.yml
+++ b/demo/cli_demo/V1.0.0__deploy_test.cli.yml
@@ -3,5 +3,5 @@ steps:
     command: sql
     args:
       - "--help"
-    working_dir: ./demo/cli_demo
+    working_dir: .
     description: "Test CLI"

--- a/demo/cli_demo/V1.0.0__deploy_test.cli.yml
+++ b/demo/cli_demo/V1.0.0__deploy_test.cli.yml
@@ -1,7 +1,16 @@
 steps:
   - cli: snow
-    command: sql
+    command: snowpark build
     args:
-      - "--help"
-    working_dir: .
-    description: "Test CLI"
+      - "--connection"
+      - "defaultold"
+    working_dir: ./foo
+    description: "Test Snowpark Build"
+  - cli: snow
+    command: snowpark deploy
+    args:
+      - "--replace"
+      - "--connection"
+      - "defaultold"
+    working_dir: ./foo
+    description: "Test Snowpark Deploy"

--- a/demo/cli_demo/V1.0.0__deploy_test.cli.yml
+++ b/demo/cli_demo/V1.0.0__deploy_test.cli.yml
@@ -1,0 +1,7 @@
+steps:
+  - cli: snow
+    command: sql
+    args:
+      - "--help"
+    working_dir: ./demo/cli_demo
+    description: "Test CLI"

--- a/demo/cli_demo/V1.0.7__test_sql_error.sql
+++ b/demo/cli_demo/V1.0.7__test_sql_error.sql
@@ -1,0 +1,1 @@
+SELECT 'FOO';

--- a/demo/cli_demo/foo/.gitignore
+++ b/demo/cli_demo/foo/.gitignore
@@ -1,0 +1,5 @@
+.packages/
+.venv/
+requirements.snowflake.txt
+app.zip
+__pycache__

--- a/demo/cli_demo/foo/app/common.py
+++ b/demo/cli_demo/foo/app/common.py
@@ -1,0 +1,2 @@
+def print_hello(name: str):
+    return f"Hello {name}!"

--- a/demo/cli_demo/foo/app/functions.py
+++ b/demo/cli_demo/foo/app/functions.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import sys
+
+from common import print_hello
+
+
+def hello_function(name: str) -> str:
+    return print_hello(name)
+
+
+# For local debugging
+# Be aware you may need to type-convert arguments if you add input parameters
+if __name__ == "__main__":
+    print(hello_function(*sys.argv[1:]))  # type: ignore

--- a/demo/cli_demo/foo/requirements.txt
+++ b/demo/cli_demo/foo/requirements.txt
@@ -1,0 +1,1 @@
+snowflake-snowpark-python

--- a/demo/cli_demo/foo/snowflake.yml
+++ b/demo/cli_demo/foo/snowflake.yml
@@ -1,0 +1,22 @@
+definition_version: '2'
+
+mixins:
+  snowpark_shared:
+    artifacts:
+      - dest: my_snowpark_project
+        src: app/
+    stage: dev_deployment
+
+entities:
+  hello_function:
+    type: function
+    identifier:
+      name: hello_function
+    handler: functions.hello_function
+    signature:
+      - name: name
+        type: string
+    returns: string
+    meta:
+      use_mixins:
+        - snowpark_shared

--- a/demo/cli_demo/schemachange-config.yml
+++ b/demo/cli_demo/schemachange-config.yml
@@ -1,0 +1,9 @@
+config-version: 1
+
+# Demo phase creates its own change history table in the test schema (separate from setup/teardown tracking)
+#change-history-table: "{{ env_var('SNOWFLAKE_DATABASE')}}.{{ env_var('MY_TARGET_SCHEMA')}}.CHANGE_HISTORY"
+#create-change-history-table: true
+
+#vars:
+#  database_name: "{{env_var('SNOWFLAKE_DATABASE')}}"
+#  schema_name: "{{env_var('MY_TARGET_SCHEMA')}}"

--- a/demo/cli_demo/schemachange-config.yml
+++ b/demo/cli_demo/schemachange-config.yml
@@ -1,9 +1,16 @@
 config-version: 1
 
-# Demo phase creates its own change history table in the test schema (separate from setup/teardown tracking)
-#change-history-table: "{{ env_var('SNOWFLAKE_DATABASE')}}.{{ env_var('MY_TARGET_SCHEMA')}}.CHANGE_HISTORY"
-#create-change-history-table: true
+# Root folder containing migration scripts
+root-folder: "."
 
-#vars:
-#  database_name: "{{env_var('SNOWFLAKE_DATABASE')}}"
-#  schema_name: "{{env_var('MY_TARGET_SCHEMA')}}"
+# For dry-run testing, we still need a change history table defined
+# (it won't actually be created/used in dry-run mode)
+change-history-table: "DEMO_DB.PUBLIC.CHANGE_HISTORY"
+#change-history-table: "TEST_DB.PUBLIC.CHANGE_HISTORY"
+create-change-history-table: true
+
+# Minimal Snowflake config for dry-run (won't actually connect)
+# You can also set these as environment variables:
+#   export SNOWFLAKE_ACCOUNT=your_account
+#   export SNOWFLAKE_USER=your_user
+#   export SNOWFLAKE_DATABASE=TEST_DB

--- a/schemachange/CLIScriptExecutionError.py
+++ b/schemachange/CLIScriptExecutionError.py
@@ -1,0 +1,78 @@
+"""Custom exception for CLI script execution failures with rich context."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+class CLIScriptExecutionError(Exception):
+    """
+    Exception raised when a CLI script execution fails.
+
+    Captures rich context about the failure including script details,
+    CLI tool information, exit codes, and output for debugging.
+    """
+
+    def __init__(
+        self,
+        script_name: str,
+        script_path: Path,
+        script_type: str,
+        error_message: str,
+        cli_tool: str | None = None,
+        command: str | None = None,
+        exit_code: int | None = None,
+        stdout: str | None = None,
+        stderr: str | None = None,
+        step_index: int | None = None,
+        original_exception: Exception | None = None,
+    ):
+        """
+        Initialize CLIScriptExecutionError with rich context.
+
+        Args:
+            script_name: Name of the script that failed
+            script_path: Path to the script file
+            script_type: Type of script (V, R, or A)
+            error_message: Human-readable error message
+            cli_tool: CLI tool that was being executed (e.g., "snow")
+            command: The CLI command that failed
+            exit_code: Process exit code
+            stdout: Captured stdout from the process
+            stderr: Captured stderr from the process
+            step_index: Index of the step that failed (0-based)
+            original_exception: The original exception that was raised
+        """
+        self.script_name = script_name
+        self.script_path = script_path
+        self.script_type = script_type
+        self.error_message = error_message
+        self.cli_tool = cli_tool
+        self.command = command
+        self.exit_code = exit_code
+        self.stdout = stdout
+        self.stderr = stderr
+        self.step_index = step_index
+        self.original_exception = original_exception
+
+        # Create user-friendly message
+        step_info = f" (step {step_index + 1})" if step_index is not None else ""
+        super().__init__(f"Failed to execute {script_type} CLI script '{script_name}'{step_info}: {error_message}")
+
+    def get_structured_error(self) -> dict:
+        """
+        Get error details as structured dict for logging.
+
+        Returns:
+            Dictionary with error details suitable for structured logging
+        """
+        return {
+            "script_name": self.script_name,
+            "script_path": self.script_path.as_posix(),
+            "script_type": self.script_type,
+            "error_message": self.error_message,
+            "cli_tool": self.cli_tool,
+            "command": self.command,
+            "exit_code": self.exit_code,
+            "step_index": self.step_index,
+        }

--- a/schemachange/JinjaTemplateProcessor.py
+++ b/schemachange/JinjaTemplateProcessor.py
@@ -42,9 +42,9 @@ class JinjaTemplateProcessor:
         # to make unit testing easier
         self.__environment = jinja2.Environment(loader=loader, **self._env_args)
 
-    def _is_cli_script(self, script: str) -> bool:
+    def _is_cli_script(self, script: str | Path) -> bool:
         """Check if the script is a CLI migration file (.cli.yml)."""
-        script_lower = script.lower()
+        script_lower = str(script).lower()
         return script_lower.endswith(".cli.yml") or script_lower.endswith(".cli.yml.jinja")
 
     def render(self, script: str, variables: dict[str, Any] | None) -> str:

--- a/schemachange/JinjaTemplateProcessor.py
+++ b/schemachange/JinjaTemplateProcessor.py
@@ -70,7 +70,6 @@ class JinjaTemplateProcessor:
                     f"CLI script '{script}' rendered to empty content after Jinja processing.\n"
                     f"Ensure the file contains valid YAML with a 'steps' key."
                 )
-            logger.debug("Rendered CLI script", script=script, content_length=len(content))
             return content
 
         # SQL-specific processing below

--- a/schemachange/JinjaTemplateProcessor.py
+++ b/schemachange/JinjaTemplateProcessor.py
@@ -42,6 +42,11 @@ class JinjaTemplateProcessor:
         # to make unit testing easier
         self.__environment = jinja2.Environment(loader=loader, **self._env_args)
 
+    def _is_cli_script(self, script: str) -> bool:
+        """Check if the script is a CLI migration file (.cli.yml)."""
+        script_lower = script.lower()
+        return script_lower.endswith(".cli.yml") or script_lower.endswith(".cli.yml.jinja")
+
     def render(self, script: str, variables: dict[str, Any] | None) -> str:
         if not variables:
             variables = {}
@@ -51,12 +56,24 @@ class JinjaTemplateProcessor:
         raw_content = template.render(**variables)
 
         # Remove UTF-8 BOM if present (issue #250)
-        # The BOM character (\ufeff) causes Snowflake SQL compilation errors
+        # The BOM character (\ufeff) causes errors
         # Common in files saved with "UTF-8 with BOM" encoding (Windows/VS Code)
         if raw_content.startswith("\ufeff"):
             logger.debug("Removing UTF-8 BOM from script", script=script)
             raw_content = raw_content[1:]
 
+        # For CLI scripts (.cli.yml), return the rendered YAML without SQL-specific processing
+        if self._is_cli_script(script):
+            content = raw_content.strip()
+            if not content:
+                raise ValueError(
+                    f"CLI script '{script}' rendered to empty content after Jinja processing.\n"
+                    f"Ensure the file contains valid YAML with a 'steps' key."
+                )
+            logger.debug("Rendered CLI script", script=script, content_length=len(content))
+            return content
+
+        # SQL-specific processing below
         content = raw_content.strip()
         content = content[:-1] if content.endswith(";") else content
 

--- a/schemachange/cli_script_executor.py
+++ b/schemachange/cli_script_executor.py
@@ -217,7 +217,7 @@ def execute_cli_step(
         step_log.info("Dry run - would execute CLI command", command=cmd_str)
         return None
 
-    step_log.info("Executing CLI command", command=cmd_str)
+    step_log.debug("Executing CLI command", command=cmd_str)
     step_log.debug(
         "CLI execution details",
         cli_path=step.cli_path,
@@ -271,7 +271,7 @@ def execute_cli_step(
                 step_index=step_index,
             )
 
-        step_log.info("CLI command completed successfully", exit_code=0)
+        step_log.debug("CLI command completed successfully", exit_code=0)
         return result
 
     except FileNotFoundError as e:
@@ -306,6 +306,10 @@ def execute_cli_step(
             step_index=step_index,
             original_exception=e,
         ) from e
+
+    except CLIScriptExecutionError:
+        # Re-raise CLIScriptExecutionError without additional wrapping/logging
+        raise
 
     except Exception as e:
         step_log.error("Unexpected error executing CLI command", error=str(e))
@@ -350,7 +354,7 @@ def execute_cli_script(
         script_format="CLI",
     )
 
-    script_log.info("Executing CLI migration script")
+    script_log.info("Applying CLI change script")
 
     # Parse the YAML content
     try:
@@ -377,8 +381,8 @@ def execute_cli_script(
 
     execution_time = round(time.time() - start_time)
 
-    script_log.info(
-        "CLI migration script completed",
+    script_log.debug(
+        "CLI change script completed",
         steps_executed=len(steps),
         execution_time_seconds=execution_time,
     )

--- a/schemachange/cli_script_executor.py
+++ b/schemachange/cli_script_executor.py
@@ -1,0 +1,327 @@
+"""CLI Script Executor for running CLI commands defined in .cli.yml migration files."""
+
+from __future__ import annotations
+
+import dataclasses
+import os
+import subprocess
+import time
+from pathlib import Path
+from typing import Any
+
+import structlog
+import yaml
+
+from schemachange.CLIScriptExecutionError import CLIScriptExecutionError
+from schemachange.session.Script import Script
+
+logger = structlog.getLogger(__name__)
+
+# Allowed CLI tools (initially only Snowflake CLI)
+ALLOWED_CLI_TOOLS = frozenset({"snow"})
+
+
+@dataclasses.dataclass(frozen=True)
+class CLIStep:
+    """Represents a single CLI command step in a CLI migration script."""
+
+    cli: str
+    command: str
+    args: tuple[str, ...] = ()
+    working_dir: Path | None = None
+    env: dict[str, str] | None = None
+    description: str | None = None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any], root_folder: Path) -> CLIStep:
+        """
+        Create a CLIStep from a dictionary parsed from YAML.
+
+        Args:
+            data: Dictionary containing step configuration
+            root_folder: Root folder for resolving relative working directories
+
+        Returns:
+            CLIStep instance
+
+        Raises:
+            ValueError: If required fields are missing or invalid
+        """
+        # Validate required fields
+        if "cli" not in data:
+            raise ValueError("Step is missing required field 'cli'")
+        if "command" not in data:
+            raise ValueError("Step is missing required field 'command'")
+
+        cli = data["cli"]
+        if cli not in ALLOWED_CLI_TOOLS:
+            raise ValueError(
+                f"CLI tool '{cli}' is not supported. Allowed tools: {', '.join(sorted(ALLOWED_CLI_TOOLS))}"
+            )
+
+        # Parse arguments
+        args = data.get("args", [])
+        if isinstance(args, str):
+            args = [args]
+        args = tuple(str(arg) for arg in args)
+
+        # Parse working directory (relative to root_folder)
+        working_dir = None
+        if "working_dir" in data and data["working_dir"]:
+            working_dir = root_folder / data["working_dir"]
+
+        # Parse environment variables
+        env = None
+        if "env" in data and data["env"]:
+            env = {str(k): str(v) for k, v in data["env"].items()}
+
+        return cls(
+            cli=cli,
+            command=data["command"],
+            args=args,
+            working_dir=working_dir,
+            env=env,
+            description=data.get("description"),
+        )
+
+
+def parse_cli_script(content: str, root_folder: Path) -> list[CLIStep]:
+    """
+    Parse CLI script YAML content into a list of CLIStep objects.
+
+    Args:
+        content: Rendered YAML content
+        root_folder: Root folder for resolving relative paths
+
+    Returns:
+        List of CLIStep objects
+
+    Raises:
+        ValueError: If YAML is invalid or schema doesn't match expected format
+    """
+    try:
+        data = yaml.safe_load(content)
+    except yaml.YAMLError as e:
+        raise ValueError(f"Invalid YAML in CLI script: {e}") from e
+
+    if not isinstance(data, dict):
+        raise ValueError("CLI script must be a YAML dictionary with a 'steps' key")
+
+    if "steps" not in data:
+        raise ValueError("CLI script is missing required 'steps' key")
+
+    steps_data = data["steps"]
+    if not isinstance(steps_data, list):
+        raise ValueError("'steps' must be a list of step definitions")
+
+    if not steps_data:
+        raise ValueError("'steps' list cannot be empty")
+
+    steps = []
+    for i, step_data in enumerate(steps_data):
+        try:
+            step = CLIStep.from_dict(step_data, root_folder)
+            steps.append(step)
+        except ValueError as e:
+            raise ValueError(f"Invalid step at index {i}: {e}") from e
+
+    return steps
+
+
+def execute_cli_step(
+    step: CLIStep,
+    step_index: int,
+    script: Script,
+    dry_run: bool,
+    log: structlog.BoundLogger,
+) -> subprocess.CompletedProcess | None:
+    """
+    Execute a single CLI step.
+
+    Args:
+        step: CLIStep to execute
+        step_index: Index of the step (for logging)
+        script: The parent script object
+        dry_run: If True, log the command without executing
+        log: Logger instance
+
+    Returns:
+        CompletedProcess if executed, None if dry_run
+
+    Raises:
+        CLIScriptExecutionError: If the command fails
+    """
+    # Build the full command
+    cmd_parts = [step.cli, *step.command.split(), *step.args]
+    cmd_str = " ".join(cmd_parts)
+
+    step_log = log.bind(
+        step_index=step_index + 1,
+        cli=step.cli,
+        command=step.command,
+        working_dir=step.working_dir.as_posix() if step.working_dir else None,
+    )
+
+    if step.description:
+        step_log = step_log.bind(step_description=step.description)
+
+    if dry_run:
+        step_log.info("Dry run - would execute CLI command", command=cmd_str)
+        return None
+
+    step_log.info("Executing CLI command", command=cmd_str)
+
+    # Prepare environment
+    env = os.environ.copy()
+    if step.env:
+        env.update(step.env)
+
+    # Determine working directory
+    cwd = step.working_dir if step.working_dir else None
+
+    try:
+        result = subprocess.run(
+            cmd_parts,
+            cwd=cwd,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,  # We'll handle errors ourselves
+        )
+
+        # Log output
+        if result.stdout:
+            for line in result.stdout.strip().split("\n"):
+                step_log.debug("CLI stdout", output=line)
+
+        if result.stderr:
+            for line in result.stderr.strip().split("\n"):
+                step_log.debug("CLI stderr", output=line)
+
+        # Check for failure
+        if result.returncode != 0:
+            error_msg = result.stderr.strip() if result.stderr else f"Command exited with code {result.returncode}"
+            step_log.error(
+                "CLI command failed",
+                exit_code=result.returncode,
+                stderr=result.stderr[:500] if result.stderr else None,
+            )
+            raise CLIScriptExecutionError(
+                script_name=script.name,
+                script_path=script.file_path,
+                script_type=script.type,
+                error_message=error_msg,
+                cli_tool=step.cli,
+                command=cmd_str,
+                exit_code=result.returncode,
+                stdout=result.stdout,
+                stderr=result.stderr,
+                step_index=step_index,
+            )
+
+        step_log.info("CLI command completed successfully", exit_code=0)
+        return result
+
+    except FileNotFoundError as e:
+        step_log.error("CLI tool not found", cli=step.cli)
+        raise CLIScriptExecutionError(
+            script_name=script.name,
+            script_path=script.file_path,
+            script_type=script.type,
+            error_message=f"CLI tool '{step.cli}' not found. Is it installed and in PATH?",
+            cli_tool=step.cli,
+            command=cmd_str,
+            step_index=step_index,
+            original_exception=e,
+        ) from e
+
+    except PermissionError as e:
+        step_log.error("Permission denied executing CLI tool", cli=step.cli)
+        raise CLIScriptExecutionError(
+            script_name=script.name,
+            script_path=script.file_path,
+            script_type=script.type,
+            error_message=f"Permission denied executing '{step.cli}'",
+            cli_tool=step.cli,
+            command=cmd_str,
+            step_index=step_index,
+            original_exception=e,
+        ) from e
+
+    except Exception as e:
+        step_log.error("Unexpected error executing CLI command", error=str(e))
+        raise CLIScriptExecutionError(
+            script_name=script.name,
+            script_path=script.file_path,
+            script_type=script.type,
+            error_message=f"Unexpected error: {str(e)}",
+            cli_tool=step.cli,
+            command=cmd_str,
+            step_index=step_index,
+            original_exception=e,
+        ) from e
+
+
+def execute_cli_script(
+    script: Script,
+    content: str,
+    root_folder: Path,
+    dry_run: bool,
+    log: structlog.BoundLogger,
+) -> int:
+    """
+    Execute a CLI migration script.
+
+    Args:
+        script: The CLI script object
+        content: Rendered YAML content (after Jinja processing)
+        root_folder: Root folder for resolving relative paths
+        dry_run: If True, log commands without executing
+        log: Logger instance
+
+    Returns:
+        Total execution time in seconds
+
+    Raises:
+        ValueError: If the script content is invalid
+        CLIScriptExecutionError: If any step fails
+    """
+    script_log = log.bind(
+        script_name=script.name,
+        script_format="CLI",
+    )
+
+    script_log.info("Executing CLI migration script")
+
+    # Parse the YAML content
+    try:
+        steps = parse_cli_script(content, root_folder)
+    except ValueError as e:
+        script_log.error("Failed to parse CLI script", error=str(e))
+        raise
+
+    script_log.debug("Parsed CLI script", step_count=len(steps))
+
+    if dry_run:
+        script_log.info("Running in dry-run mode. Commands will be logged but not executed.")
+
+    # Execute each step
+    start_time = time.time()
+    for i, step in enumerate(steps):
+        execute_cli_step(
+            step=step,
+            step_index=i,
+            script=script,
+            dry_run=dry_run,
+            log=script_log,
+        )
+
+    execution_time = round(time.time() - start_time)
+
+    script_log.info(
+        "CLI migration script completed",
+        steps_executed=len(steps),
+        execution_time_seconds=execution_time,
+    )
+
+    return execution_time

--- a/schemachange/cli_script_executor.py
+++ b/schemachange/cli_script_executor.py
@@ -357,9 +357,9 @@ def execute_cli_script(
     )
 
     if out_of_order:
-        script_log.info("Applying CLI change script (out-of-order)")
+        script_log.info(f"Applying {script.type_desc} change script (out-of-order)")
     else:
-        script_log.info("Applying CLI change script")
+        script_log.info(f"Applying {script.type_desc} change script")
 
     # Parse the YAML content
     try:

--- a/schemachange/cli_script_executor.py
+++ b/schemachange/cli_script_executor.py
@@ -331,6 +331,7 @@ def execute_cli_script(
     root_folder: Path,
     dry_run: bool,
     log: structlog.BoundLogger,
+    out_of_order: bool = False,
 ) -> int:
     """
     Execute a CLI migration script.
@@ -341,6 +342,7 @@ def execute_cli_script(
         root_folder: Root folder for resolving relative paths
         dry_run: If True, log commands without executing
         log: Logger instance
+        out_of_order: If True, indicates this versioned script is being applied out of order
 
     Returns:
         Total execution time in seconds
@@ -354,7 +356,10 @@ def execute_cli_script(
         script_format="CLI",
     )
 
-    script_log.info("Applying CLI change script")
+    if out_of_order:
+        script_log.info("Applying CLI change script (out-of-order)")
+    else:
+        script_log.info("Applying CLI change script")
 
     # Parse the YAML content
     try:

--- a/schemachange/config/DeployConfig.py
+++ b/schemachange/config/DeployConfig.py
@@ -44,6 +44,7 @@ class DeployConfig(BaseConfig):
     snowflake_token_file_path: str | None = None
     version_number_validation_regex: str | None = None
     raise_exception_on_ignored_versioned_script: bool = False
+    out_of_order: bool = False  # Allow applying migrations with versions older than max_published_version
     session_parameters: dict | None = None  # Session parameters from CLI/ENV/YAML (merged with connections.toml)
     additional_snowflake_params: dict | None = None  # Parameters from YAML v2 or generic SNOWFLAKE_* env vars
 

--- a/schemachange/config/parse_cli_args.py
+++ b/schemachange/config/parse_cli_args.py
@@ -372,6 +372,19 @@ def parse_cli_args(args) -> dict:
         "(Deprecated alias: --raise-exception-on-ignored-versioned-script)",
         required=False,
     )
+    parser_deploy.add_argument(
+        "--out-of-order",
+        action="store_const",
+        const=True,
+        default=None,
+        dest="out_of_order",
+        help="Allow versioned scripts to be applied out of order. When enabled, scripts are only skipped "
+        "if they have already been applied, regardless of whether their version is older than the max "
+        "published version. Useful for parallel development with timestamp-based versioning "
+        "(the default is False). "
+        "Can also be set via SCHEMACHANGE_OUT_OF_ORDER environment variable.",
+        required=False,
+    )
 
     parser_render = subcommands.add_parser(
         "render",

--- a/schemachange/config/utils.py
+++ b/schemachange/config/utils.py
@@ -967,6 +967,7 @@ def get_schemachange_config_from_env() -> dict:
         "SCHEMACHANGE_AUTOCOMMIT": "autocommit",
         "SCHEMACHANGE_DRY_RUN": "dry_run",
         "SCHEMACHANGE_RAISE_EXCEPTION_ON_IGNORED_VERSIONED_SCRIPT": "raise_exception_on_ignored_versioned_script",
+        "SCHEMACHANGE_OUT_OF_ORDER": "out_of_order",
     }
 
     for env_var, param_name in bool_params.items():

--- a/schemachange/deploy.py
+++ b/schemachange/deploy.py
@@ -139,7 +139,6 @@ def deploy(config: DeployConfig, session: SnowflakeSession):
         # Execute the script based on its format (SQL or CLI)
         if script.format == "CLI":
             # Execute CLI script via subprocess
-            script_log.info("Applying CLI migration script")
             execution_time = execute_cli_script(
                 script=script,
                 content=content,

--- a/schemachange/deploy.py
+++ b/schemachange/deploy.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import hashlib
-import re
 
 import structlog
 
@@ -11,35 +10,16 @@ from schemachange.config.DeployConfig import DeployConfig
 from schemachange.JinjaTemplateProcessor import JinjaTemplateProcessor
 from schemachange.session.Script import get_all_scripts_recursively
 from schemachange.session.SnowflakeSession import SnowflakeSession
+from schemachange.version import get_alphanum_key, sorted_alphanumeric
 
 logger = structlog.getLogger(__name__)
 
 
-def alphanum_convert(text: str):
-    if text.isdigit():
-        return int(text)
-    return text.lower()
-
-
-# This function will return a list containing the parts of the key (split by number parts)
-# Each number is converted to and integer and string parts are left as strings
-# This will enable correct sorting in python when the lists are compared
-# e.g. get_alphanum_key('1.2.2') results in ['', 1, '.', 2, '.', 2, '']
-def get_alphanum_key(key: str | int | None) -> list:
-    if key == "" or key is None:
-        return []
-    alphanum_key = [alphanum_convert(c) for c in re.split("([0-9]+)", key)]
-    return alphanum_key
-
-
-def sorted_alphanumeric(data):
-    return sorted(data, key=get_alphanum_key)
-
-
 def deploy(config: DeployConfig, session: SnowflakeSession):
     logger.info(
-        "starting deploy",
+        "Starting deploy",
         dry_run=config.dry_run,
+        out_of_order=config.out_of_order,
         snowflake_account=session.account,
         default_role=session.role,
         default_warehouse=session.warehouse,
@@ -93,13 +73,24 @@ def deploy(config: DeployConfig, session: SnowflakeSession):
 
         checksum_current = hashlib.sha224(content.encode("utf-8")).hexdigest()
 
-        # Apply a versioned-change script only if the version is newer than the most recent change in the database
-        # Apply any other scripts, i.e. repeatable scripts, irrespective of the most recent change in the database
+        # Apply a versioned-change script based on whether it has been applied and version ordering rules
         if script.type == "V":
             script_metadata = versioned_scripts.get(script.name)
 
-            if max_published_version is not None and get_alphanum_key(script.version) <= max_published_version:
-                if script_metadata is None:
+            # First check: Has this script already been applied?
+            if script_metadata is not None:
+                script_log.debug(
+                    "Script has already been applied",
+                    max_published_version=max_published_version,
+                )
+                if script_metadata["checksum"] != checksum_current:
+                    script_log.info("Script checksum has drifted since application")
+                scripts_skipped += 1
+                continue
+
+            # Second check: Version ordering (only if out_of_order is disabled)
+            if not config.out_of_order:
+                if max_published_version is not None and get_alphanum_key(script.version) <= max_published_version:
                     if config.raise_exception_on_ignored_versioned_script:
                         raise ValueError(
                             f"Versioned script will never be applied: {script.name}\n"
@@ -112,16 +103,6 @@ def deploy(config: DeployConfig, session: SnowflakeSession):
                         )
                         scripts_skipped += 1
                         continue
-                else:
-                    script_log.debug(
-                        "Script has already been applied",
-                        max_published_version=max_published_version,
-                    )
-                    if script_metadata["checksum"] != checksum_current:
-                        script_log.info("Script checksum has drifted since application")
-
-                    scripts_skipped += 1
-                    continue
 
         # Apply only R scripts where the checksum changed compared to the last execution of snowchange
         if script.type == "R":
@@ -170,12 +151,21 @@ def deploy(config: DeployConfig, session: SnowflakeSession):
                     )
                 raise  # Re-raise the exception after recording
         else:
+            # Determine if this is an out-of-order execution (versioned script with version <= max)
+            is_out_of_order = (
+                script.type == "V"
+                and config.out_of_order
+                and max_published_version is not None
+                and get_alphanum_key(script.version) <= max_published_version
+            )
+
             # Execute SQL script via Snowflake session
             session.apply_change_script(
                 script=script,
                 script_content=content,
                 dry_run=config.dry_run,
                 logger=script_log,
+                out_of_order=is_out_of_order,
             )
 
         scripts_applied += 1

--- a/schemachange/session/Script.py
+++ b/schemachange/session/Script.py
@@ -35,7 +35,7 @@ class Script(ABC):
 
     @classmethod
     def from_path(cls, file_path: Path, **kwargs) -> T:
-        logger.debug("script found", class_name=cls.__name__, file_path=file_path.as_posix())
+        logger.debug("Script found", class_name=cls.__name__, file_path=file_path.as_posix())
 
         # script name is the filename without any jinja extension
         script_name = cls.get_script_name(file_path=file_path)

--- a/schemachange/session/Script.py
+++ b/schemachange/session/Script.py
@@ -26,6 +26,15 @@ class Script(ABC):
     file_path: Path
     description: str
 
+    @property
+    def type_desc(self) -> str:
+        """Return a descriptive string for the script type, including version for V scripts and format."""
+        parts = [self.type]
+        if self.type == "V" and hasattr(self, "version"):
+            parts.append(f"({self.version})")
+        parts.append(self.format)
+        return " ".join(parts)
+
     @staticmethod
     def get_script_name(file_path: Path) -> str:
         """Script name is the filename without any jinja extension"""

--- a/schemachange/session/SnowflakeSession.py
+++ b/schemachange/session/SnowflakeSession.py
@@ -478,10 +478,11 @@ class SnowflakeSession:
         if dry_run:
             logger.info("Running in dry-run mode. Skipping execution")
             return
+
         if out_of_order:
-            logger.info("Applying change script (out-of-order)")
+            logger.info(f"Applying {script.type_desc} change script (out-of-order)")
         else:
-            logger.info("Applying change script")
+            logger.info(f"Applying {script.type_desc} change script")
         # Define a few other change related variables
         # noinspection PyTypeChecker
         checksum = hashlib.sha224(script_content.encode("utf-8")).hexdigest()

--- a/schemachange/version.py
+++ b/schemachange/version.py
@@ -1,0 +1,58 @@
+"""
+Version comparison utilities for schemachange.
+
+These functions provide alphanumeric version comparison that correctly handles
+semantic versioning, timestamp-based versions, and other common versioning schemes.
+"""
+
+from __future__ import annotations
+
+import re
+
+
+def alphanum_convert(text: str):
+    """Convert a string to int if it's numeric, otherwise lowercase it."""
+    if text.isdigit():
+        return int(text)
+    return text.lower()
+
+
+def get_alphanum_key(key: str | int | None) -> list:
+    """
+    Return a list containing the parts of the key (split by number parts).
+
+    Each number is converted to an integer and string parts are left as strings.
+    This enables correct sorting in Python when the lists are compared.
+
+    Example:
+        get_alphanum_key('1.2.2') results in ['', 1, '.', 2, '.', 2, '']
+        get_alphanum_key('1.0.10') results in ['', 1, '.', 0, '.', 10, '']
+
+    This ensures that '1.0.10' > '1.0.2' (correct) rather than '1.0.10' < '1.0.2' (string comparison).
+    """
+    if key == "" or key is None:
+        return []
+    alphanum_key = [alphanum_convert(c) for c in re.split("([0-9]+)", str(key))]
+    return alphanum_key
+
+
+def sorted_alphanumeric(data):
+    """Sort a list of strings using alphanumeric comparison."""
+    return sorted(data, key=get_alphanum_key)
+
+
+def max_alphanumeric(versions: list[str | int | None]) -> str | int | None:
+    """
+    Find the maximum version from a list using alphanumeric comparison.
+
+    Args:
+        versions: List of version strings/numbers (may contain None values)
+
+    Returns:
+        The maximum version, or None if the list is empty or contains only None values
+    """
+    # Filter out None and empty values
+    valid_versions = [v for v in versions if v is not None and v != ""]
+    if not valid_versions:
+        return None
+    return max(valid_versions, key=get_alphanum_key)

--- a/tests/test_cli_misc.py
+++ b/tests/test_cli_misc.py
@@ -5,7 +5,7 @@ import pytest
 from schemachange.cli import SCHEMACHANGE_VERSION, SNOWFLAKE_APPLICATION_NAME
 from schemachange.config.ChangeHistoryTable import ChangeHistoryTable
 from schemachange.config.utils import get_snowflake_identifier_string
-from schemachange.deploy import alphanum_convert, get_alphanum_key, sorted_alphanumeric
+from schemachange.version import alphanum_convert, get_alphanum_key, sorted_alphanumeric
 
 
 def test_cli_given__schemachange_version_change_updated_in_setup_config_file():

--- a/tests/test_cli_script_executor.py
+++ b/tests/test_cli_script_executor.py
@@ -1,0 +1,376 @@
+"""Tests for CLI script executor functionality."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import structlog
+
+from schemachange.cli_script_executor import (
+    ALLOWED_CLI_TOOLS,
+    CLIStep,
+    execute_cli_script,
+    execute_cli_step,
+    parse_cli_script,
+)
+from schemachange.CLIScriptExecutionError import CLIScriptExecutionError
+from schemachange.session.Script import VersionedCLIScript
+
+
+class TestCLIStep:
+    def test_from_dict_minimal(self):
+        data = {"cli": "snow", "command": "app deploy"}
+        step = CLIStep.from_dict(data, Path("/root"))
+
+        assert step.cli == "snow"
+        assert step.command == "app deploy"
+        assert step.args == ()
+        assert step.working_dir is None
+        assert step.env is None
+        assert step.description is None
+
+    def test_from_dict_full(self):
+        data = {
+            "cli": "snow",
+            "command": "app deploy",
+            "args": ["--prune", "--recursive"],
+            "working_dir": "./my-app",
+            "env": {"MY_VAR": "value"},
+            "description": "Deploy the app",
+        }
+        step = CLIStep.from_dict(data, Path("/root"))
+
+        assert step.cli == "snow"
+        assert step.command == "app deploy"
+        assert step.args == ("--prune", "--recursive")
+        assert step.working_dir == Path("/root/my-app")
+        assert step.env == {"MY_VAR": "value"}
+        assert step.description == "Deploy the app"
+
+    def test_from_dict_string_args(self):
+        data = {"cli": "snow", "command": "app deploy", "args": "--force"}
+        step = CLIStep.from_dict(data, Path("/root"))
+
+        assert step.args == ("--force",)
+
+    def test_from_dict_missing_cli_raises_error(self):
+        data = {"command": "app deploy"}
+        with pytest.raises(ValueError) as e:
+            CLIStep.from_dict(data, Path("/root"))
+        assert "missing required field 'cli'" in str(e.value)
+
+    def test_from_dict_missing_command_raises_error(self):
+        data = {"cli": "snow"}
+        with pytest.raises(ValueError) as e:
+            CLIStep.from_dict(data, Path("/root"))
+        assert "missing required field 'command'" in str(e.value)
+
+    def test_from_dict_unsupported_cli_raises_error(self):
+        data = {"cli": "unsupported_tool", "command": "do something"}
+        with pytest.raises(ValueError) as e:
+            CLIStep.from_dict(data, Path("/root"))
+        assert "not supported" in str(e.value)
+        assert "unsupported_tool" in str(e.value)
+
+
+class TestParseCLIScript:
+    def test_parse_valid_single_step(self):
+        content = """
+steps:
+  - cli: snow
+    command: app deploy
+"""
+        steps = parse_cli_script(content, Path("/root"))
+
+        assert len(steps) == 1
+        assert steps[0].cli == "snow"
+        assert steps[0].command == "app deploy"
+
+    def test_parse_valid_multiple_steps(self):
+        content = """
+steps:
+  - cli: snow
+    command: app deploy
+    working_dir: ./app1
+  - cli: snow
+    command: snowpark deploy
+    working_dir: ./snowpark
+"""
+        steps = parse_cli_script(content, Path("/root"))
+
+        assert len(steps) == 2
+        assert steps[0].command == "app deploy"
+        assert steps[1].command == "snowpark deploy"
+
+    def test_parse_invalid_yaml_raises_error(self):
+        content = "this is not: valid: yaml: ::::"
+        with pytest.raises(ValueError) as e:
+            parse_cli_script(content, Path("/root"))
+        assert "Invalid YAML" in str(e.value)
+
+    def test_parse_missing_steps_key_raises_error(self):
+        content = """
+cli: snow
+command: app deploy
+"""
+        with pytest.raises(ValueError) as e:
+            parse_cli_script(content, Path("/root"))
+        assert "missing required 'steps' key" in str(e.value)
+
+    def test_parse_steps_not_list_raises_error(self):
+        content = """
+steps:
+  cli: snow
+  command: app deploy
+"""
+        with pytest.raises(ValueError) as e:
+            parse_cli_script(content, Path("/root"))
+        assert "'steps' must be a list" in str(e.value)
+
+    def test_parse_empty_steps_raises_error(self):
+        content = """
+steps: []
+"""
+        with pytest.raises(ValueError) as e:
+            parse_cli_script(content, Path("/root"))
+        assert "'steps' list cannot be empty" in str(e.value)
+
+    def test_parse_invalid_step_raises_error_with_index(self):
+        content = """
+steps:
+  - cli: snow
+    command: app deploy
+  - cli: snow
+"""
+        with pytest.raises(ValueError) as e:
+            parse_cli_script(content, Path("/root"))
+        assert "Invalid step at index 1" in str(e.value)
+
+
+class TestExecuteCLIStep:
+    @pytest.fixture
+    def mock_script(self):
+        return VersionedCLIScript(
+            name="V1.0.0__deploy.cli.yml",
+            file_path=Path("/scripts/V1.0.0__deploy.cli.yml"),
+            description="Deploy",
+            version="1.0.0",
+        )
+
+    @pytest.fixture
+    def mock_logger(self):
+        return structlog.get_logger()
+
+    def test_dry_run_does_not_execute(self, mock_script, mock_logger):
+        step = CLIStep(cli="snow", command="app deploy")
+
+        with patch("schemachange.cli_script_executor.subprocess.run") as mock_run:
+            result = execute_cli_step(step, 0, mock_script, dry_run=True, log=mock_logger)
+
+        mock_run.assert_not_called()
+        assert result is None
+
+    def test_successful_execution(self, mock_script, mock_logger):
+        step = CLIStep(cli="snow", command="app deploy")
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "Deployed successfully"
+        mock_result.stderr = ""
+
+        with patch("schemachange.cli_script_executor.subprocess.run", return_value=mock_result) as mock_run:
+            result = execute_cli_step(step, 0, mock_script, dry_run=False, log=mock_logger)
+
+        mock_run.assert_called_once()
+        assert result.returncode == 0
+
+    def test_failed_execution_raises_error(self, mock_script, mock_logger):
+        step = CLIStep(cli="snow", command="app deploy")
+
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stdout = ""
+        mock_result.stderr = "Error: deployment failed"
+
+        with patch("schemachange.cli_script_executor.subprocess.run", return_value=mock_result):
+            with pytest.raises(CLIScriptExecutionError) as e:
+                execute_cli_step(step, 0, mock_script, dry_run=False, log=mock_logger)
+
+        assert e.value.exit_code == 1
+        assert e.value.cli_tool == "snow"
+        assert e.value.step_index == 0
+
+    def test_cli_not_found_raises_error(self, mock_script, mock_logger):
+        step = CLIStep(cli="snow", command="app deploy")
+
+        with patch("schemachange.cli_script_executor.subprocess.run", side_effect=FileNotFoundError()):
+            with pytest.raises(CLIScriptExecutionError) as e:
+                execute_cli_step(step, 0, mock_script, dry_run=False, log=mock_logger)
+
+        assert "not found" in str(e.value.error_message)
+
+    def test_step_with_working_dir(self, mock_script, mock_logger):
+        step = CLIStep(cli="snow", command="app deploy", working_dir=Path("/my/app"))
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = ""
+        mock_result.stderr = ""
+
+        with patch("schemachange.cli_script_executor.subprocess.run", return_value=mock_result) as mock_run:
+            execute_cli_step(step, 0, mock_script, dry_run=False, log=mock_logger)
+
+        call_kwargs = mock_run.call_args[1]
+        assert call_kwargs["cwd"] == Path("/my/app")
+
+    def test_step_with_env_vars(self, mock_script, mock_logger):
+        step = CLIStep(cli="snow", command="app deploy", env={"MY_VAR": "value"})
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = ""
+        mock_result.stderr = ""
+
+        with patch("schemachange.cli_script_executor.subprocess.run", return_value=mock_result) as mock_run:
+            with patch.dict("os.environ", {"EXISTING": "var"}, clear=True):
+                execute_cli_step(step, 0, mock_script, dry_run=False, log=mock_logger)
+
+        call_kwargs = mock_run.call_args[1]
+        assert "MY_VAR" in call_kwargs["env"]
+        assert call_kwargs["env"]["MY_VAR"] == "value"
+
+
+class TestExecuteCLIScript:
+    @pytest.fixture
+    def mock_script(self):
+        return VersionedCLIScript(
+            name="V1.0.0__deploy.cli.yml",
+            file_path=Path("/scripts/V1.0.0__deploy.cli.yml"),
+            description="Deploy",
+            version="1.0.0",
+        )
+
+    @pytest.fixture
+    def mock_logger(self):
+        return structlog.get_logger()
+
+    def test_execute_single_step_script(self, mock_script, mock_logger):
+        content = """
+steps:
+  - cli: snow
+    command: app deploy
+"""
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "Success"
+        mock_result.stderr = ""
+
+        with patch("schemachange.cli_script_executor.subprocess.run", return_value=mock_result):
+            execution_time = execute_cli_script(
+                script=mock_script,
+                content=content,
+                root_folder=Path("/root"),
+                dry_run=False,
+                log=mock_logger,
+            )
+
+        assert execution_time >= 0
+
+    def test_execute_dry_run(self, mock_script, mock_logger):
+        content = """
+steps:
+  - cli: snow
+    command: app deploy
+"""
+        with patch("schemachange.cli_script_executor.subprocess.run") as mock_run:
+            execution_time = execute_cli_script(
+                script=mock_script,
+                content=content,
+                root_folder=Path("/root"),
+                dry_run=True,
+                log=mock_logger,
+            )
+
+        mock_run.assert_not_called()
+        assert execution_time >= 0
+
+    def test_execute_invalid_yaml_raises_error(self, mock_script, mock_logger):
+        content = "not valid yaml :::"
+
+        with pytest.raises(ValueError):
+            execute_cli_script(
+                script=mock_script,
+                content=content,
+                root_folder=Path("/root"),
+                dry_run=False,
+                log=mock_logger,
+            )
+
+    def test_execute_step_failure_stops_execution(self, mock_script, mock_logger):
+        content = """
+steps:
+  - cli: snow
+    command: step1
+  - cli: snow
+    command: step2
+"""
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stdout = ""
+        mock_result.stderr = "Error"
+
+        with patch("schemachange.cli_script_executor.subprocess.run", return_value=mock_result):
+            with pytest.raises(CLIScriptExecutionError) as e:
+                execute_cli_script(
+                    script=mock_script,
+                    content=content,
+                    root_folder=Path("/root"),
+                    dry_run=False,
+                    log=mock_logger,
+                )
+
+        # Should fail on first step
+        assert e.value.step_index == 0
+
+
+class TestCLIScriptExecutionError:
+    def test_error_message_includes_step_info(self):
+        error = CLIScriptExecutionError(
+            script_name="V1.0.0__deploy.cli.yml",
+            script_path=Path("/scripts/V1.0.0__deploy.cli.yml"),
+            script_type="V",
+            error_message="Command failed",
+            step_index=2,
+        )
+
+        assert "step 3" in str(error)  # 0-indexed, so step 2 is displayed as step 3
+
+    def test_get_structured_error(self):
+        error = CLIScriptExecutionError(
+            script_name="V1.0.0__deploy.cli.yml",
+            script_path=Path("/scripts/V1.0.0__deploy.cli.yml"),
+            script_type="V",
+            error_message="Command failed",
+            cli_tool="snow",
+            command="snow app deploy",
+            exit_code=1,
+            step_index=0,
+        )
+
+        structured = error.get_structured_error()
+
+        assert structured["script_name"] == "V1.0.0__deploy.cli.yml"
+        assert structured["cli_tool"] == "snow"
+        assert structured["exit_code"] == 1
+        assert structured["step_index"] == 0
+
+
+class TestAllowedCLITools:
+    def test_snow_is_allowed(self):
+        assert "snow" in ALLOWED_CLI_TOOLS
+
+    def test_only_snow_is_allowed_initially(self):
+        # Per design doc, only snow is supported initially
+        assert ALLOWED_CLI_TOOLS == frozenset({"snow"})

--- a/tests/test_out_of_order.py
+++ b/tests/test_out_of_order.py
@@ -1,0 +1,479 @@
+"""
+Tests for the out-of-order versioned script execution feature.
+
+This feature allows versioned scripts to be applied even if their version number
+is older than the max_published_version in the change history table. This is useful
+for parallel development scenarios with timestamp-based versioning.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections import defaultdict
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from schemachange.config.DeployConfig import DeployConfig
+from schemachange.deploy import deploy
+from schemachange.version import get_alphanum_key, max_alphanumeric
+
+# Minimal config for testing
+minimal_deploy_config_kwargs: dict = {
+    "snowflake_account": "test_account",
+    "snowflake_user": "test_user",
+    "snowflake_role": "test_role",
+    "snowflake_warehouse": "test_warehouse",
+}
+
+
+class TestOutOfOrderConfig:
+    """Test out_of_order configuration option."""
+
+    @mock.patch("pathlib.Path.is_dir", return_value=True)
+    def test_out_of_order_defaults_to_false(self, _):
+        """Test that out_of_order defaults to False for backward compatibility."""
+        config = DeployConfig.factory(
+            config_file_path=Path("."),
+            **minimal_deploy_config_kwargs,
+        )
+        assert config.out_of_order is False
+
+    @mock.patch("pathlib.Path.is_dir", return_value=True)
+    def test_out_of_order_can_be_enabled(self, _):
+        """Test that out_of_order can be set to True."""
+        config = DeployConfig.factory(
+            config_file_path=Path("."),
+            out_of_order=True,
+            **minimal_deploy_config_kwargs,
+        )
+        assert config.out_of_order is True
+
+
+class TestOutOfOrderDeployLogic:
+    """Test the deploy logic with out_of_order enabled/disabled."""
+
+    @pytest.fixture
+    def mock_session(self):
+        """Create a mock SnowflakeSession."""
+        session = mock.MagicMock()
+        session.account = "test_account"
+        session.role = "test_role"
+        session.warehouse = "test_warehouse"
+        session.database = "test_database"
+        session.schema = "test_schema"
+        session.change_history_table.fully_qualified = "METADATA.SCHEMACHANGE.CHANGE_HISTORY"
+        return session
+
+    @pytest.fixture
+    def mock_config_base(self):
+        """Create base config kwargs."""
+        return {
+            "config_file_path": Path("."),
+            "root_folder": Path("."),
+            "dry_run": False,
+            "create_change_history_table": False,
+            "raise_exception_on_ignored_versioned_script": False,
+            "config_vars": {},
+            "modules_folder": None,
+            **minimal_deploy_config_kwargs,
+        }
+
+    def _create_mock_script(self, name: str, version: str, content: str = "SELECT 1;"):
+        """Helper to create a mock versioned script."""
+        script = mock.MagicMock()
+        script.name = name
+        script.version = version
+        script.type = "V"
+        script.format = "SQL"
+        script.file_path = Path(f"/migrations/{name}")
+        return script, content
+
+    @mock.patch("pathlib.Path.is_dir", return_value=True)
+    @mock.patch("schemachange.deploy.get_all_scripts_recursively")
+    @mock.patch("schemachange.deploy.JinjaTemplateProcessor")
+    def test_out_of_order_disabled_skips_older_unapplied_scripts(
+        self, mock_jinja, mock_get_scripts, _, mock_session, mock_config_base
+    ):
+        """
+        Test that with out_of_order=False (default), unapplied scripts older than
+        max_published_version are skipped.
+
+        Scenario: V1.0.3 has been applied (max_published_version = 1.0.3)
+                  V1.0.2 is present but was never applied
+                  Expected: V1.0.2 should be skipped
+        """
+        # Setup: V1.0.3 was applied, V1.0.2 was not
+        script_v102, content_v102 = self._create_mock_script("v1.0.2__feature_a.sql", "1.0.2")
+        mock_get_scripts.return_value = {"v1.0.2__feature_a.sql": script_v102}
+
+        # Mock jinja processor
+        mock_processor = mock.MagicMock()
+        mock_processor.render.return_value = content_v102
+        mock_processor.relpath.return_value = "v1.0.2__feature_a.sql"
+        mock_jinja.return_value = mock_processor
+
+        # Mock session: V1.0.3 was applied (versioned_scripts doesn't contain v1.0.2)
+        versioned_scripts = defaultdict(dict)  # V1.0.2 not in here = never applied
+        mock_session.get_script_metadata.return_value = (versioned_scripts, None, "1.0.3")
+
+        # Create config with out_of_order=False (default)
+        config = DeployConfig.factory(out_of_order=False, **mock_config_base)
+
+        # Run deploy
+        deploy(config, mock_session)
+
+        # Verify: apply_change_script should NOT be called (script was skipped)
+        mock_session.apply_change_script.assert_not_called()
+
+    @mock.patch("pathlib.Path.is_dir", return_value=True)
+    @mock.patch("schemachange.deploy.get_all_scripts_recursively")
+    @mock.patch("schemachange.deploy.JinjaTemplateProcessor")
+    def test_out_of_order_enabled_applies_older_unapplied_scripts(
+        self, mock_jinja, mock_get_scripts, _, mock_session, mock_config_base
+    ):
+        """
+        Test that with out_of_order=True, unapplied scripts older than
+        max_published_version are applied.
+
+        Scenario: V1.0.3 has been applied (max_published_version = 1.0.3)
+                  V1.0.2 is present but was never applied
+                  Expected: V1.0.2 should be applied
+        """
+        # Setup: V1.0.3 was applied, V1.0.2 was not
+        script_v102, content_v102 = self._create_mock_script("v1.0.2__feature_a.sql", "1.0.2")
+        mock_get_scripts.return_value = {"v1.0.2__feature_a.sql": script_v102}
+
+        # Mock jinja processor
+        mock_processor = mock.MagicMock()
+        mock_processor.render.return_value = content_v102
+        mock_processor.relpath.return_value = "v1.0.2__feature_a.sql"
+        mock_jinja.return_value = mock_processor
+
+        # Mock session: V1.0.3 was applied (versioned_scripts doesn't contain v1.0.2)
+        versioned_scripts = defaultdict(dict)  # V1.0.2 not in here = never applied
+        mock_session.get_script_metadata.return_value = (versioned_scripts, None, "1.0.3")
+
+        # Create config with out_of_order=True
+        config = DeployConfig.factory(out_of_order=True, **mock_config_base)
+
+        # Run deploy
+        deploy(config, mock_session)
+
+        # Verify: apply_change_script SHOULD be called
+        mock_session.apply_change_script.assert_called_once()
+        call_args = mock_session.apply_change_script.call_args
+        assert call_args.kwargs["script"] == script_v102
+
+    @mock.patch("pathlib.Path.is_dir", return_value=True)
+    @mock.patch("schemachange.deploy.get_all_scripts_recursively")
+    @mock.patch("schemachange.deploy.JinjaTemplateProcessor")
+    def test_already_applied_scripts_always_skipped(
+        self, mock_jinja, mock_get_scripts, _, mock_session, mock_config_base
+    ):
+        """
+        Test that scripts already recorded in change history are skipped
+        regardless of out_of_order setting.
+        """
+        script_v102, content_v102 = self._create_mock_script("v1.0.2__feature_a.sql", "1.0.2")
+        mock_get_scripts.return_value = {"v1.0.2__feature_a.sql": script_v102}
+
+        # Mock jinja processor
+        mock_processor = mock.MagicMock()
+        mock_processor.render.return_value = content_v102
+        mock_processor.relpath.return_value = "v1.0.2__feature_a.sql"
+        mock_jinja.return_value = mock_processor
+
+        # Mock session: V1.0.2 was ALREADY applied
+        checksum = hashlib.sha224(content_v102.encode("utf-8")).hexdigest()
+        versioned_scripts = defaultdict(dict)
+        versioned_scripts["v1.0.2__feature_a.sql"] = {
+            "version": "1.0.2",
+            "script": "v1.0.2__feature_a.sql",
+            "checksum": checksum,
+        }
+        mock_session.get_script_metadata.return_value = (versioned_scripts, None, "1.0.3")
+
+        # Create config with out_of_order=True
+        config = DeployConfig.factory(out_of_order=True, **mock_config_base)
+
+        # Run deploy
+        deploy(config, mock_session)
+
+        # Verify: apply_change_script should NOT be called (already applied)
+        mock_session.apply_change_script.assert_not_called()
+
+    @mock.patch("pathlib.Path.is_dir", return_value=True)
+    @mock.patch("schemachange.deploy.get_all_scripts_recursively")
+    @mock.patch("schemachange.deploy.JinjaTemplateProcessor")
+    def test_out_of_order_disabled_with_raise_exception_raises(
+        self, mock_jinja, mock_get_scripts, _, mock_session, mock_config_base
+    ):
+        """
+        Test that with out_of_order=False and raise_exception_on_ignored=True,
+        an exception is raised for unapplied older scripts.
+        """
+        script_v102, content_v102 = self._create_mock_script("v1.0.2__feature_a.sql", "1.0.2")
+        mock_get_scripts.return_value = {"v1.0.2__feature_a.sql": script_v102}
+
+        # Mock jinja processor
+        mock_processor = mock.MagicMock()
+        mock_processor.render.return_value = content_v102
+        mock_processor.relpath.return_value = "v1.0.2__feature_a.sql"
+        mock_jinja.return_value = mock_processor
+
+        # Mock session: V1.0.3 was applied, V1.0.2 was not
+        versioned_scripts = defaultdict(dict)
+        mock_session.get_script_metadata.return_value = (versioned_scripts, None, "1.0.3")
+
+        # Create config with out_of_order=False and raise_exception=True
+        mock_config_base["raise_exception_on_ignored_versioned_script"] = True
+        config = DeployConfig.factory(out_of_order=False, **mock_config_base)
+
+        # Run deploy - should raise
+        with pytest.raises(ValueError) as exc_info:
+            deploy(config, mock_session)
+
+        assert "Versioned script will never be applied" in str(exc_info.value)
+        assert "v1.0.2__feature_a.sql" in str(exc_info.value)
+
+    @mock.patch("pathlib.Path.is_dir", return_value=True)
+    @mock.patch("schemachange.deploy.get_all_scripts_recursively")
+    @mock.patch("schemachange.deploy.JinjaTemplateProcessor")
+    def test_out_of_order_enabled_ignores_raise_exception_flag(
+        self, mock_jinja, mock_get_scripts, _, mock_session, mock_config_base
+    ):
+        """
+        Test that with out_of_order=True, the raise_exception flag is irrelevant
+        because the script gets applied instead of being ignored.
+        """
+        script_v102, content_v102 = self._create_mock_script("v1.0.2__feature_a.sql", "1.0.2")
+        mock_get_scripts.return_value = {"v1.0.2__feature_a.sql": script_v102}
+
+        # Mock jinja processor
+        mock_processor = mock.MagicMock()
+        mock_processor.render.return_value = content_v102
+        mock_processor.relpath.return_value = "v1.0.2__feature_a.sql"
+        mock_jinja.return_value = mock_processor
+
+        # Mock session: V1.0.3 was applied, V1.0.2 was not
+        versioned_scripts = defaultdict(dict)
+        mock_session.get_script_metadata.return_value = (versioned_scripts, None, "1.0.3")
+
+        # Create config with out_of_order=True AND raise_exception=True
+        mock_config_base["raise_exception_on_ignored_versioned_script"] = True
+        config = DeployConfig.factory(out_of_order=True, **mock_config_base)
+
+        # Run deploy - should NOT raise, should apply
+        deploy(config, mock_session)
+
+        # Verify: apply_change_script SHOULD be called
+        mock_session.apply_change_script.assert_called_once()
+
+    @mock.patch("pathlib.Path.is_dir", return_value=True)
+    @mock.patch("schemachange.deploy.get_all_scripts_recursively")
+    @mock.patch("schemachange.deploy.JinjaTemplateProcessor")
+    def test_multiple_out_of_order_scripts_applied(
+        self, mock_jinja, mock_get_scripts, _, mock_session, mock_config_base
+    ):
+        """
+        Test that multiple out-of-order scripts are all applied.
+
+        Scenario: V1.0.5 has been applied (max_published_version = 1.0.5)
+                  V1.0.2, V1.0.3, V1.0.4 are present but never applied
+                  Expected: All three should be applied in order
+        """
+        script_v102, content_v102 = self._create_mock_script("v1.0.2__feature_a.sql", "1.0.2")
+        script_v103, content_v103 = self._create_mock_script("v1.0.3__feature_b.sql", "1.0.3")
+        script_v104, content_v104 = self._create_mock_script("v1.0.4__feature_c.sql", "1.0.4")
+
+        mock_get_scripts.return_value = {
+            "v1.0.2__feature_a.sql": script_v102,
+            "v1.0.3__feature_b.sql": script_v103,
+            "v1.0.4__feature_c.sql": script_v104,
+        }
+
+        # Mock jinja processor to return appropriate content for each script
+        mock_processor = mock.MagicMock()
+        content_map = {
+            "v1.0.2__feature_a.sql": content_v102,
+            "v1.0.3__feature_b.sql": content_v103,
+            "v1.0.4__feature_c.sql": content_v104,
+        }
+        mock_processor.render.side_effect = lambda path, _: content_map.get(path, "SELECT 1;")
+        mock_processor.relpath.side_effect = lambda path: path.name
+        mock_jinja.return_value = mock_processor
+
+        # Mock session: V1.0.5 was applied, none of V1.0.2-V1.0.4 were
+        versioned_scripts = defaultdict(dict)
+        mock_session.get_script_metadata.return_value = (versioned_scripts, None, "1.0.5")
+
+        # Create config with out_of_order=True
+        config = DeployConfig.factory(out_of_order=True, **mock_config_base)
+
+        # Run deploy
+        deploy(config, mock_session)
+
+        # Verify: apply_change_script should be called 3 times
+        assert mock_session.apply_change_script.call_count == 3
+
+    @mock.patch("pathlib.Path.is_dir", return_value=True)
+    @mock.patch("schemachange.deploy.get_all_scripts_recursively")
+    @mock.patch("schemachange.deploy.JinjaTemplateProcessor")
+    def test_newer_scripts_always_applied(self, mock_jinja, mock_get_scripts, _, mock_session, mock_config_base):
+        """
+        Test that scripts newer than max_published_version are always applied
+        regardless of out_of_order setting.
+        """
+        script_v104, content_v104 = self._create_mock_script("v1.0.4__feature.sql", "1.0.4")
+        mock_get_scripts.return_value = {"v1.0.4__feature.sql": script_v104}
+
+        # Mock jinja processor
+        mock_processor = mock.MagicMock()
+        mock_processor.render.return_value = content_v104
+        mock_processor.relpath.return_value = "v1.0.4__feature.sql"
+        mock_jinja.return_value = mock_processor
+
+        # Mock session: V1.0.3 was applied
+        versioned_scripts = defaultdict(dict)
+        mock_session.get_script_metadata.return_value = (versioned_scripts, None, "1.0.3")
+
+        # Test with out_of_order=False (default)
+        config = DeployConfig.factory(out_of_order=False, **mock_config_base)
+
+        # Run deploy
+        deploy(config, mock_session)
+
+        # Verify: apply_change_script SHOULD be called (newer version)
+        mock_session.apply_change_script.assert_called_once()
+
+
+class TestOutOfOrderCLI:
+    """Test CLI argument parsing for out_of_order."""
+
+    def test_out_of_order_cli_argument_parsed(self):
+        """Test that --out-of-order CLI argument is parsed correctly."""
+        from schemachange.config.parse_cli_args import parse_cli_args
+
+        args = parse_cli_args(["deploy", "--out-of-order"])
+        assert args.get("out_of_order") is True
+
+    def test_out_of_order_cli_argument_absent(self):
+        """Test that out_of_order is None when not provided."""
+        from schemachange.config.parse_cli_args import parse_cli_args
+
+        args = parse_cli_args(["deploy"])
+        assert args.get("out_of_order") is None
+
+
+class TestOutOfOrderEnvVar:
+    """Test environment variable for out_of_order."""
+
+    @mock.patch.dict("os.environ", {"SCHEMACHANGE_OUT_OF_ORDER": "true"})
+    def test_out_of_order_env_var_true(self):
+        """Test that SCHEMACHANGE_OUT_OF_ORDER=true is parsed correctly."""
+        from schemachange.config.utils import get_schemachange_config_from_env
+
+        env_config = get_schemachange_config_from_env()
+        assert env_config.get("out_of_order") is True
+
+    @mock.patch.dict("os.environ", {"SCHEMACHANGE_OUT_OF_ORDER": "false"})
+    def test_out_of_order_env_var_false(self):
+        """Test that SCHEMACHANGE_OUT_OF_ORDER=false is parsed correctly."""
+        from schemachange.config.utils import get_schemachange_config_from_env
+
+        env_config = get_schemachange_config_from_env()
+        assert env_config.get("out_of_order") is False
+
+    @mock.patch.dict("os.environ", {}, clear=True)
+    def test_out_of_order_env_var_absent(self):
+        """Test that out_of_order is not present when env var is not set."""
+        from schemachange.config.utils import get_schemachange_config_from_env
+
+        env_config = get_schemachange_config_from_env()
+        assert "out_of_order" not in env_config
+
+
+class TestAlphanumKey:
+    """Test get_alphanum_key function used for version comparison."""
+
+    def test_simple_version(self):
+        """Test simple version number."""
+        assert get_alphanum_key("1.0.0") == ["", 1, ".", 0, ".", 0, ""]
+
+    def test_timestamp_version(self):
+        """Test timestamp-based version number."""
+        key = get_alphanum_key("20260122143052")
+        assert key == ["", 20260122143052, ""]
+
+    def test_version_comparison(self):
+        """Test that version comparison works correctly."""
+        v100 = get_alphanum_key("1.0.0")
+        v101 = get_alphanum_key("1.0.1")
+        v110 = get_alphanum_key("1.1.0")
+
+        assert v100 < v101
+        assert v101 < v110
+        assert v100 < v110
+
+    def test_timestamp_comparison(self):
+        """Test that timestamp comparison works correctly."""
+        t1 = get_alphanum_key("20260122143052")
+        t2 = get_alphanum_key("20260122143053")
+        t3 = get_alphanum_key("20260123000000")
+
+        assert t1 < t2
+        assert t2 < t3
+
+
+class TestMaxAlphanumeric:
+    """Test max_alphanumeric function used to find the highest version."""
+
+    def test_simple_versions(self):
+        """Test finding max among simple versions."""
+        versions = ["1.0.0", "1.0.1", "1.1.0", "2.0.0"]
+        assert max_alphanumeric(versions) == "2.0.0"
+
+    def test_semantic_versioning_with_double_digits(self):
+        """Test that 1.0.10 > 1.0.2 (not string comparison)."""
+        versions = ["1.0.2", "1.0.10", "1.0.1"]
+        assert max_alphanumeric(versions) == "1.0.10"
+
+    def test_out_of_order_versions(self):
+        """Test finding max when versions were applied out of order."""
+        # Simulates: V1.0.3 applied first, V1.0.2 applied second (out of order)
+        versions = ["1.0.3", "1.0.2"]
+        assert max_alphanumeric(versions) == "1.0.3"
+
+    def test_timestamp_versions(self):
+        """Test finding max among timestamp-based versions."""
+        versions = ["20260122143052", "20260121000000", "20260122154512"]
+        assert max_alphanumeric(versions) == "20260122154512"
+
+    def test_empty_list(self):
+        """Test with empty list."""
+        assert max_alphanumeric([]) is None
+
+    def test_list_with_none_values(self):
+        """Test with None values in list."""
+        versions = [None, "1.0.0", None, "1.0.1"]
+        assert max_alphanumeric(versions) == "1.0.1"
+
+    def test_list_with_empty_strings(self):
+        """Test with empty strings in list."""
+        versions = ["", "1.0.0", "", "1.0.1"]
+        assert max_alphanumeric(versions) == "1.0.1"
+
+    def test_list_with_only_none(self):
+        """Test with only None values."""
+        versions = [None, None]
+        assert max_alphanumeric(versions) is None
+
+    def test_mixed_version_styles(self):
+        """Test with mixed version styles."""
+        # Timestamp-based versions sort higher than semantic versions
+        versions = ["1.0.0", "20260122143052", "2.0.0"]
+        result = max_alphanumeric(versions)
+        # Timestamp should be highest due to the large number
+        assert result == "20260122143052"


### PR DESCRIPTION
**Added**

- **CLI Migration Scripts (`.cli.yml`)**: Execute CLI commands as part of your deployment process. Deploy complex Snowflake objects like dbt projects or Snowpark functions using the Snowflake CLI (`snow`) directly from schemachange:
    - Supports all script types: Versioned (`V`), Repeatable (`R`), and Always (`A`)
    - YAML-based step definitions with command, args, working directory, and environment variables
    - Jinja templating support via `.cli.yml.jinja` extension
    - Full change history tracking with Success/Failed status
- **Out-of-Order Execution (`--out-of-order`)**: Allow versioned scripts to be applied regardless of whether their version is older than the maximum applied version. Useful for parallel development workflows where branches merge in any order:
    - CLI flag: `--out-of-order`
    - Environment variable: `SCHEMACHANGE_OUT_OF_ORDER`
    - YAML config: `out-of-order: true`
- **Failed Script Logging**: Script execution failures are now recorded in the change history table with `STATUS = 'Failed'`, improving visibility and troubleshooting

**Fixed**

- **Password from connections.toml not being passed to Snowflake connector**: The password parameter from `connections.toml` is now correctly passed through to the Snowflake connector. This fix enables proper password authentication when credentials are defined in `connections.toml`.