### PR TITLE
fix: avoid re-running run-once migrations (409)

### DIFF
--- a/schemachange/session/SnowflakeSession.py
+++ b/schemachange/session/SnowflakeSession.py
@@ -254,8 +254,7 @@ class SnowflakeSession:
         if self.change_history_table is None:
             raise ValueError("change_history_table is required for deployment operations")
         # This should only ever return 0 or 1 rows.
-        # Use UPPER() so lookup is case-insensitive: Snowflake stores identifiers in
-        # uppercase in INFORMATION_SCHEMA (fixes #409).
+        # UPPER() for case-insensitive match with INFORMATION_SCHEMA.
         query = f"""\
             SELECT
                 CREATED,
@@ -278,7 +277,7 @@ class SnowflakeSession:
     def change_history_schema_exists(self) -> bool:
         if self.change_history_table is None:
             raise ValueError("change_history_table is required for deployment operations")
-        # Use UPPER() for case-insensitive match with INFORMATION_SCHEMA (#409).
+        # UPPER() for case-insensitive match with INFORMATION_SCHEMA.
         query = f"""\
             SELECT
                 COUNT(1)

--- a/schemachange/session/SnowflakeSession.py
+++ b/schemachange/session/SnowflakeSession.py
@@ -253,14 +253,16 @@ class SnowflakeSession:
     def fetch_change_history_metadata(self) -> dict:
         if self.change_history_table is None:
             raise ValueError("change_history_table is required for deployment operations")
-        # This should only ever return 0 or 1 rows
+        # This should only ever return 0 or 1 rows.
+        # Use UPPER() so lookup is case-insensitive: Snowflake stores identifiers in
+        # uppercase in INFORMATION_SCHEMA (fixes #409).
         query = f"""\
             SELECT
                 CREATED,
                 LAST_ALTERED
             FROM {self.change_history_table.database_name}.INFORMATION_SCHEMA.TABLES
-            WHERE TABLE_SCHEMA = REPLACE('{self.change_history_table.schema_name}','\"','')
-                AND TABLE_NAME = REPLACE('{self.change_history_table.table_name}','\"','')
+            WHERE TABLE_SCHEMA = UPPER(REPLACE('{self.change_history_table.schema_name}','\"',''))
+                AND TABLE_NAME = UPPER(REPLACE('{self.change_history_table.table_name}','\"',''))
         """
         results = self.execute_snowflake_query(query=dedent(query), logger=self.logger)
 
@@ -276,11 +278,12 @@ class SnowflakeSession:
     def change_history_schema_exists(self) -> bool:
         if self.change_history_table is None:
             raise ValueError("change_history_table is required for deployment operations")
+        # Use UPPER() for case-insensitive match with INFORMATION_SCHEMA (#409).
         query = f"""\
             SELECT
                 COUNT(1)
             FROM {self.change_history_table.database_name}.INFORMATION_SCHEMA.SCHEMATA
-            WHERE SCHEMA_NAME = REPLACE('{self.change_history_table.schema_name}','\"','')
+            WHERE SCHEMA_NAME = UPPER(REPLACE('{self.change_history_table.schema_name}','\"',''))
         """
         results = self.execute_snowflake_query(dedent(query), logger=self.logger)
         for cursor in results:

--- a/tests/session/test_SnowflakeSession.py
+++ b/tests/session/test_SnowflakeSession.py
@@ -64,6 +64,50 @@ class TestSnowflakeSession:
         assert result == {}
         assert session.con.execute_string.call_count == 1
 
+    def test_fetch_change_history_metadata_uses_upper_for_information_schema(self):
+        """Regression test for #409: INFORMATION_SCHEMA stores names in uppercase.
+
+        When change_history_table has lowercase schema/table names (e.g. from config),
+        the query must use UPPER() so it matches Snowflake's INFORMATION_SCHEMA.TABLES.
+        Otherwise the lookup returns no rows and schemachange re-runs all versioned scripts.
+        """
+        change_history_table = ChangeHistoryTable(
+            database_name="mydb",
+            schema_name="myschema",
+            table_name="change_history",
+        )
+        logger = structlog.testing.CapturingLogger()
+        with mock.patch("snowflake.connector.connect") as mock_connect:
+            mock_conn = mock.Mock()
+            mock_conn.account = "account"
+            mock_conn.user = "user"
+            mock_conn.role = "role"
+            mock_conn.warehouse = "warehouse"
+            mock_conn.database = None
+            mock_conn.schema = None
+            mock_conn.session_id = "session_123"
+            mock_connect.return_value = mock_conn
+            with mock.patch("schemachange.session.SnowflakeSession.get_snowflake_identifier_string"):
+                session = SnowflakeSession(
+                    user="user",
+                    account="account",
+                    role="role",
+                    warehouse="warehouse",
+                    schemachange_version="3.6.1.dev",
+                    application="schemachange",
+                    change_history_table=change_history_table,
+                    logger=logger,
+                )
+        session.con.execute_string.reset_mock()
+        session.con.execute_string.return_value = [[["2020-01-01", "2020-01-02"]]]
+        session.fetch_change_history_metadata()
+        call_args = session.con.execute_string.call_args
+        query = call_args[0][0]
+        assert "UPPER(REPLACE(" in query, (
+            "Query must use UPPER(REPLACE(...)) for TABLE_SCHEMA and TABLE_NAME so "
+            "INFORMATION_SCHEMA lookup is case-insensitive (Snowflake stores names in uppercase)."
+        )
+
     def test_snowflake_session_with_additional_params_from_yaml_v2(self):
         """Test that additional_snowflake_params from YAML v2 are passed to connector."""
         change_history_table = ChangeHistoryTable()

--- a/tests/session/test_SnowflakeSession.py
+++ b/tests/session/test_SnowflakeSession.py
@@ -65,12 +65,7 @@ class TestSnowflakeSession:
         assert session.con.execute_string.call_count == 1
 
     def test_fetch_change_history_metadata_uses_upper_for_information_schema(self):
-        """Regression test for #409: INFORMATION_SCHEMA stores names in uppercase.
-
-        When change_history_table has lowercase schema/table names (e.g. from config),
-        the query must use UPPER() so it matches Snowflake's INFORMATION_SCHEMA.TABLES.
-        Otherwise the lookup returns no rows and schemachange re-runs all versioned scripts.
-        """
+        """INFORMATION_SCHEMA stores names in uppercase; query must use UPPER() for lookup."""
         change_history_table = ChangeHistoryTable(
             database_name="mydb",
             schema_name="myschema",
@@ -101,12 +96,8 @@ class TestSnowflakeSession:
         session.con.execute_string.reset_mock()
         session.con.execute_string.return_value = [[["2020-01-01", "2020-01-02"]]]
         session.fetch_change_history_metadata()
-        call_args = session.con.execute_string.call_args
-        query = call_args[0][0]
-        assert "UPPER(REPLACE(" in query, (
-            "Query must use UPPER(REPLACE(...)) for TABLE_SCHEMA and TABLE_NAME so "
-            "INFORMATION_SCHEMA lookup is case-insensitive (Snowflake stores names in uppercase)."
-        )
+        query = session.con.execute_string.call_args[0][0]
+        assert "UPPER(REPLACE(" in query
 
     def test_snowflake_session_with_additional_params_from_yaml_v2(self):
         """Test that additional_snowflake_params from YAML v2 are passed to connector."""


### PR DESCRIPTION
# Pull Request: Fix INFORMATION_SCHEMA case sensitivity (#409)

## Summary

Fixes the bug where schemachange re-deploys all versioned scripts when the change history table is specified with lowercase schema/table names (e.g. `mydb.myschema.change_history`). Snowflake stores identifiers in **uppercase** in `INFORMATION_SCHEMA`; the previous query used a case-sensitive comparison, so the lookup returned no rows and schemachange treated the table as missing.

## Problem

- **Issue:** [#409 – Case sensitivity of the config file](https://github.com/Snowflake-Labs/schemachange/issues/409)
- **Symptom:** "When running schemachange it deploys everything every time. I get a lot of duplicate versions in the SCHEMACHANGE_CHANGE_HISTORY table."
- **Root cause:** `fetch_change_history_metadata()` and `change_history_schema_exists()` compared against `INFORMATION_SCHEMA` using `REPLACE('schema_name','"','')` without normalizing case. Snowflake returns `TABLE_SCHEMA = 'MYSCHEMA'`, so `'myschema' != 'MYSCHEMA'` and the query returns no rows.

## Solution

Use `UPPER(REPLACE(...))` in the WHERE clause for:

1. **`fetch_change_history_metadata()`** – `TABLE_SCHEMA` and `TABLE_NAME` in the `INFORMATION_SCHEMA.TABLES` query.
2. **`change_history_schema_exists()`** – `SCHEMA_NAME` in the `INFORMATION_SCHEMA.SCHEMATA` query.

No change to object references (e.g. `fully_qualified`); Snowflake is already case-insensitive for those. Only the INFORMATION_SCHEMA lookups are fixed.

## Testing

- **New test:** `test_fetch_change_history_metadata_uses_upper_for_information_schema` – builds a session with lowercase `ChangeHistoryTable` and asserts the executed query contains `UPPER(REPLACE(` so the lookup is case-insensitive.

## Checklist

- [x] Tests pass (`pytest`)
- [x] Code formatted (`ruff format .`)
- [x] Lint clean (`ruff check .`)
- [x] Test added for the fix
- [ ] CHANGELOG.md