### PR TITLE
feat: validate change history table schema upfront, add ERROR_MESSAGE column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,18 @@ All notable changes to this project will be documented in this file.
 *The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).*
 
 ## [Unreleased]
+### Added
+- **Error messages in change history**: Failed scripts now record the Snowflake error text in a new `ERROR_MESSAGE` column of the change history table (alongside the existing `STATUS`), making failures diagnosable directly from the change history.
+- **Upfront change history schema validation**: Before running any scripts, schemachange verifies the change history table has the required columns. If a table created by an older version is missing `ERROR_MESSAGE`, the column is added automatically on the first deploy (`ALTER TABLE ... ADD COLUMN IF NOT EXISTS ERROR_MESSAGE VARCHAR`). In `--dry-run` mode it only warns.
+
 ### Fixed
 - **R script checksum mismatch** ([#435](https://github.com/Snowflake-Labs/schemachange/issues/435)): Fixed a bug where R scripts with trailing comments (e.g. `-- comment` after the last `;`) were re-applied on every deployment even when unchanged. The root cause was `apply_change_script()` recomputing the checksum on post-transformation content instead of using the pre-transformation checksum from `deploy.py`.
 
 ### Upgrade Notes
+- **New `ALTER TABLE` privilege requirement:** The deploying role now needs `ALTER TABLE` on the change history table (previously only `SELECT`/`INSERT` were required), so schemachange can add the new `ERROR_MESSAGE` column on the first deploy after upgrading. Least-privilege deployments will fail on that first run unless the role has `ALTER TABLE`, or an operator adds the column manually beforehand:
+  ```sql
+  ALTER TABLE <change_history_table> ADD COLUMN IF NOT EXISTS ERROR_MESSAGE VARCHAR;
+  ```
 - **Note for users with R scripts that have trailing comments:** If you deployed R scripts with trailing comments under v4.3.x, their checksums stored in the change history table were computed from the post-transformation content. On the **first deploy after upgrading**, those scripts will be re-applied once (schemachange will see a checksum mismatch). For idempotent scripts this is harmless; non-idempotent R scripts should be reviewed before upgrading.
 
 ## [4.3.3] - 2026-04-20

--- a/README.md
+++ b/README.md
@@ -473,6 +473,7 @@ CREATE TABLE IF NOT EXISTS SCHEMACHANGE.CHANGE_HISTORY
     CHECKSUM       VARCHAR,
     EXECUTION_TIME NUMBER,
     STATUS         VARCHAR,
+    ERROR_MESSAGE  VARCHAR,
     INSTALLED_BY   VARCHAR,
     INSTALLED_ON   TIMESTAMP_LTZ
 )
@@ -1235,7 +1236,10 @@ The Snowflake user running schemachange needs appropriate privileges:
 **Minimum Required:**
 - `USAGE` on the target database and schema
 - `SELECT` and `INSERT` on the change history table
+- `ALTER` on the change history table, so schemachange can add the `ERROR_MESSAGE` column to tables created by older versions (see note below)
 - Privileges to execute your change scripts (e.g., `CREATE TABLE`, `CREATE VIEW`, etc.)
+
+> **Note:** On the first deploy after upgrading, schemachange validates the change history table schema and adds the `ERROR_MESSAGE` column if it is missing. This requires `ALTER` on the table. If your deployment role cannot be granted `ALTER`, add the column once manually with a privileged role: `ALTER TABLE <change_history_table> ADD COLUMN IF NOT EXISTS ERROR_MESSAGE VARCHAR;`
 
 **For automatic change history table creation:**
 - `CREATE SCHEMA` on the metadata database (if using `--create-change-history-table`)
@@ -1246,8 +1250,8 @@ The Snowflake user running schemachange needs appropriate privileges:
 GRANT USAGE ON DATABASE my_database TO ROLE deployment_role;
 GRANT USAGE ON SCHEMA my_database.my_schema TO ROLE deployment_role;
 
--- Grant change history table access
-GRANT SELECT, INSERT ON TABLE metadata.schemachange.change_history TO ROLE deployment_role;
+-- Grant change history table access (ALTER lets schemachange add the ERROR_MESSAGE column)
+GRANT SELECT, INSERT, ALTER ON TABLE metadata.schemachange.change_history TO ROLE deployment_role;
 
 -- Grant privileges for change scripts
 GRANT CREATE TABLE, CREATE VIEW ON SCHEMA my_database.my_schema TO ROLE deployment_role;

--- a/schemachange/session/SnowflakeSession.py
+++ b/schemachange/session/SnowflakeSession.py
@@ -311,6 +311,7 @@ class SnowflakeSession:
                 CHECKSUM VARCHAR,
                 EXECUTION_TIME NUMBER,
                 STATUS VARCHAR,
+                ERROR_MESSAGE VARCHAR,
                 INSTALLED_BY VARCHAR,
                 INSTALLED_ON TIMESTAMP_LTZ
             )
@@ -376,6 +377,9 @@ class SnowflakeSession:
             f"Using existing change history table {self.change_history_table.fully_qualified}",
             last_altered=change_history_metadata["last_altered"],
         )
+
+        # Validate schema before running any scripts
+        self.validate_change_history_schema(dry_run=dry_run)
 
         change_history, max_published_version = self.fetch_versioned_scripts()
         r_scripts_checksum = self.fetch_repeatable_scripts()
@@ -487,18 +491,15 @@ class SnowflakeSession:
         # noinspection PyTypeChecker
         checksum = hashlib.sha224(script_content.encode("utf-8")).hexdigest()
         execution_time = 0
-
-        # Execute the contents of the script
+        start = time.time()
         if len(script_content) > 0:
-            start = time.time()
             self.reset_session(logger=logger)
             self.reset_query_tag(extra_tag=script.name, logger=logger)
             try:
                 self.execute_snowflake_query(query=script_content, logger=logger)
             except snowflake.connector.errors.ProgrammingError as e:
                 # SQL syntax/logic errors
-                end = time.time()
-                execution_time = round(end - start)
+                execution_time = round(time.time() - start)
                 logger.error(
                     "SQL execution failed",
                     script_name=script.name,
@@ -515,6 +516,7 @@ class SnowflakeSession:
                     checksum=checksum,
                     execution_time=execution_time,
                     status="Failed",
+                    error_message=str(e),
                     logger=logger,
                 )
 
@@ -531,8 +533,7 @@ class SnowflakeSession:
 
             except snowflake.connector.errors.DatabaseError as e:
                 # Connection, permission, warehouse errors
-                end = time.time()
-                execution_time = round(end - start)
+                execution_time = round(time.time() - start)
                 logger.error(
                     "Database error during script execution",
                     script_name=script.name,
@@ -547,6 +548,7 @@ class SnowflakeSession:
                     checksum=checksum,
                     execution_time=execution_time,
                     status="Failed",
+                    error_message=str(e),
                     logger=logger,
                 )
 
@@ -560,8 +562,7 @@ class SnowflakeSession:
 
             except Exception as e:
                 # Unexpected errors
-                end = time.time()
-                execution_time = round(end - start)
+                execution_time = round(time.time() - start)
                 logger.error(
                     "Unexpected error during script execution",
                     script_name=script.name,
@@ -577,6 +578,7 @@ class SnowflakeSession:
                     checksum=checksum,
                     execution_time=execution_time,
                     status="Failed",
+                    error_message=str(e),
                     logger=logger,
                 )
 
@@ -587,10 +589,11 @@ class SnowflakeSession:
                     error_message=f"Unexpected error: {str(e)}",
                     original_exception=e,
                 ) from e
-            self.reset_query_tag(logger=logger)
-            self.reset_session(logger=logger)
-            end = time.time()
-            execution_time = round(end - start)
+            finally:
+                self.reset_query_tag(logger=logger)
+                self.reset_session(logger=logger)
+
+        execution_time = round(time.time() - start)
 
         # Record the successful script execution in change history
         self.record_change_history(
@@ -598,8 +601,58 @@ class SnowflakeSession:
             checksum=checksum,
             execution_time=execution_time,
             status="Success",
+            error_message="",
             logger=logger,
         )
+
+    def validate_change_history_schema(self, dry_run: bool = False) -> None:
+        """
+        Validate that the change history table has all required columns.
+
+        If ERROR_MESSAGE is missing (e.g., table was created by an older version of schemachange),
+        this method attempts to ALTER the table to add it. In dry-run mode it only warns.
+        If the role lacks ALTER privileges in a real deploy, it fails immediately with a clear
+        message telling the user what to run manually.
+        """
+        if self.change_history_table is None:
+            raise ValueError("change_history_table is required for deployment operations")
+
+        # Fast metadata-only check: LIMIT 0 resolves column names without scanning any data
+        check_query = f"SELECT ERROR_MESSAGE FROM {self.change_history_table.fully_qualified} LIMIT 0"
+        try:
+            self.execute_snowflake_query(check_query, logger=self.logger)
+            return  # Column exists
+        except snowflake.connector.errors.ProgrammingError:
+            pass  # Column is missing, proceed to add it
+
+        if dry_run:
+            self.logger.warning(
+                "Change history table is missing the ERROR_MESSAGE column. "
+                "A real deploy would attempt to add it automatically.",
+                table=self.change_history_table.fully_qualified,
+            )
+            return
+
+        self.logger.info(
+            "Change history table is missing ERROR_MESSAGE column, attempting to add it",
+            table=self.change_history_table.fully_qualified,
+        )
+        alter_query = (
+            f"ALTER TABLE {self.change_history_table.fully_qualified} "
+            "ADD COLUMN IF NOT EXISTS ERROR_MESSAGE VARCHAR"
+        )
+        try:
+            self.execute_snowflake_query(alter_query, logger=self.logger)
+            self.logger.info("Added ERROR_MESSAGE column to change history table")
+        except Exception as e:
+            raise ValueError(
+                f"Change history table {self.change_history_table.fully_qualified} is missing the "
+                f"ERROR_MESSAGE column and schemachange was unable to add it automatically. "
+                f"Please run the following SQL manually with a role that has ALTER TABLE privileges:\n\n"
+                f"    ALTER TABLE {self.change_history_table.fully_qualified} "
+                f"ADD COLUMN IF NOT EXISTS ERROR_MESSAGE VARCHAR;\n\n"
+                f"Original error: {e}"
+            ) from e
 
     def record_change_history(
         self,
@@ -613,6 +666,7 @@ class SnowflakeSession:
         execution_time: int,
         status: str,
         logger: structlog.BoundLogger,
+        error_message: str = "",
     ) -> None:
         """
         Record a script execution in the change history table.
@@ -625,11 +679,13 @@ class SnowflakeSession:
             checksum: SHA-224 checksum of the rendered script content
             execution_time: Execution time in seconds
             status: Execution status (e.g., "Success")
+            error_message: Error message for failed scripts (optional)
             logger: Logger instance for this operation
         """
         if self.change_history_table is None:
             raise ValueError("change_history_table is required for deployment operations")
-
+        script_version = getattr(script, "version", "")
+        error_message = (error_message or "").replace("'", "''")
         query = f"""\
             INSERT INTO {self.change_history_table.fully_qualified} (
                 VERSION,
@@ -639,16 +695,18 @@ class SnowflakeSession:
                 CHECKSUM,
                 EXECUTION_TIME,
                 STATUS,
+                ERROR_MESSAGE,
                 INSTALLED_BY,
                 INSTALLED_ON
             ) VALUES (
-                '{getattr(script, "version", "")}',
+                '{script_version}',
                 '{script.description}',
                 '{script.name}',
                 '{script.type}',
                 '{checksum}',
                 {execution_time},
                 '{status}',
+                '{error_message}',
                 '{self.user}',
                 CURRENT_TIMESTAMP
             );

--- a/schemachange/session/SnowflakeSession.py
+++ b/schemachange/session/SnowflakeSession.py
@@ -493,6 +493,9 @@ class SnowflakeSession:
         if checksum is None:
             checksum = hashlib.sha224(script_content.encode("utf-8")).hexdigest()
         execution_time = 0
+        # Timed from here through the finally block below, so the recorded execution_time
+        # intentionally includes the reset_session()/reset_query_tag() round-trips as well
+        # as the script itself.
         start = time.time()
         if len(script_content) > 0:
             self.reset_session(logger=logger)
@@ -624,8 +627,14 @@ class SnowflakeSession:
         try:
             self.execute_snowflake_query(check_query, logger=self.logger)
             return  # Column exists
-        except snowflake.connector.errors.ProgrammingError:
-            pass  # Column is missing, proceed to add it
+        except snowflake.connector.errors.ProgrammingError as e:
+            # Only "invalid identifier" (Snowflake error 904) means the column is missing.
+            # Any other ProgrammingError (wrong database/schema, insufficient privileges, etc.)
+            # is a real problem and must surface with its true root cause rather than be
+            # misreported as a missing ERROR_MESSAGE column.
+            if getattr(e, "errno", None) != 904 and "invalid identifier" not in str(e).lower():
+                raise
+            # Column is missing, proceed to add it
 
         if dry_run:
             self.logger.warning(
@@ -640,8 +649,7 @@ class SnowflakeSession:
             table=self.change_history_table.fully_qualified,
         )
         alter_query = (
-            f"ALTER TABLE {self.change_history_table.fully_qualified} "
-            "ADD COLUMN IF NOT EXISTS ERROR_MESSAGE VARCHAR"
+            f"ALTER TABLE {self.change_history_table.fully_qualified} ADD COLUMN IF NOT EXISTS ERROR_MESSAGE VARCHAR"
         )
         try:
             self.execute_snowflake_query(alter_query, logger=self.logger)

--- a/schemachange/session/SnowflakeSession.py
+++ b/schemachange/session/SnowflakeSession.py
@@ -311,6 +311,7 @@ class SnowflakeSession:
                 CHECKSUM VARCHAR,
                 EXECUTION_TIME NUMBER,
                 STATUS VARCHAR,
+                ERROR_MESSAGE VARCHAR,
                 INSTALLED_BY VARCHAR,
                 INSTALLED_ON TIMESTAMP_LTZ
             )
@@ -376,6 +377,9 @@ class SnowflakeSession:
             f"Using existing change history table {self.change_history_table.fully_qualified}",
             last_altered=change_history_metadata["last_altered"],
         )
+
+        # Validate schema before running any scripts
+        self.validate_change_history_schema(dry_run=dry_run)
 
         change_history, max_published_version = self.fetch_versioned_scripts()
         r_scripts_checksum = self.fetch_repeatable_scripts()
@@ -489,18 +493,15 @@ class SnowflakeSession:
         if checksum is None:
             checksum = hashlib.sha224(script_content.encode("utf-8")).hexdigest()
         execution_time = 0
-
-        # Execute the contents of the script
+        start = time.time()
         if len(script_content) > 0:
-            start = time.time()
             self.reset_session(logger=logger)
             self.reset_query_tag(extra_tag=script.name, logger=logger)
             try:
                 self.execute_snowflake_query(query=script_content, logger=logger)
             except snowflake.connector.errors.ProgrammingError as e:
                 # SQL syntax/logic errors
-                end = time.time()
-                execution_time = round(end - start)
+                execution_time = round(time.time() - start)
                 logger.error(
                     "SQL execution failed",
                     script_name=script.name,
@@ -517,6 +518,7 @@ class SnowflakeSession:
                     checksum=checksum,
                     execution_time=execution_time,
                     status="Failed",
+                    error_message=str(e),
                     logger=logger,
                 )
 
@@ -533,8 +535,7 @@ class SnowflakeSession:
 
             except snowflake.connector.errors.DatabaseError as e:
                 # Connection, permission, warehouse errors
-                end = time.time()
-                execution_time = round(end - start)
+                execution_time = round(time.time() - start)
                 logger.error(
                     "Database error during script execution",
                     script_name=script.name,
@@ -549,6 +550,7 @@ class SnowflakeSession:
                     checksum=checksum,
                     execution_time=execution_time,
                     status="Failed",
+                    error_message=str(e),
                     logger=logger,
                 )
 
@@ -562,8 +564,7 @@ class SnowflakeSession:
 
             except Exception as e:
                 # Unexpected errors
-                end = time.time()
-                execution_time = round(end - start)
+                execution_time = round(time.time() - start)
                 logger.error(
                     "Unexpected error during script execution",
                     script_name=script.name,
@@ -579,6 +580,7 @@ class SnowflakeSession:
                     checksum=checksum,
                     execution_time=execution_time,
                     status="Failed",
+                    error_message=str(e),
                     logger=logger,
                 )
 
@@ -589,10 +591,11 @@ class SnowflakeSession:
                     error_message=f"Unexpected error: {str(e)}",
                     original_exception=e,
                 ) from e
-            self.reset_query_tag(logger=logger)
-            self.reset_session(logger=logger)
-            end = time.time()
-            execution_time = round(end - start)
+            finally:
+                self.reset_query_tag(logger=logger)
+                self.reset_session(logger=logger)
+
+        execution_time = round(time.time() - start)
 
         # Record the successful script execution in change history
         self.record_change_history(
@@ -600,8 +603,58 @@ class SnowflakeSession:
             checksum=checksum,
             execution_time=execution_time,
             status="Success",
+            error_message="",
             logger=logger,
         )
+
+    def validate_change_history_schema(self, dry_run: bool = False) -> None:
+        """
+        Validate that the change history table has all required columns.
+
+        If ERROR_MESSAGE is missing (e.g., table was created by an older version of schemachange),
+        this method attempts to ALTER the table to add it. In dry-run mode it only warns.
+        If the role lacks ALTER privileges in a real deploy, it fails immediately with a clear
+        message telling the user what to run manually.
+        """
+        if self.change_history_table is None:
+            raise ValueError("change_history_table is required for deployment operations")
+
+        # Fast metadata-only check: LIMIT 0 resolves column names without scanning any data
+        check_query = f"SELECT ERROR_MESSAGE FROM {self.change_history_table.fully_qualified} LIMIT 0"
+        try:
+            self.execute_snowflake_query(check_query, logger=self.logger)
+            return  # Column exists
+        except snowflake.connector.errors.ProgrammingError:
+            pass  # Column is missing, proceed to add it
+
+        if dry_run:
+            self.logger.warning(
+                "Change history table is missing the ERROR_MESSAGE column. "
+                "A real deploy would attempt to add it automatically.",
+                table=self.change_history_table.fully_qualified,
+            )
+            return
+
+        self.logger.info(
+            "Change history table is missing ERROR_MESSAGE column, attempting to add it",
+            table=self.change_history_table.fully_qualified,
+        )
+        alter_query = (
+            f"ALTER TABLE {self.change_history_table.fully_qualified} "
+            "ADD COLUMN IF NOT EXISTS ERROR_MESSAGE VARCHAR"
+        )
+        try:
+            self.execute_snowflake_query(alter_query, logger=self.logger)
+            self.logger.info("Added ERROR_MESSAGE column to change history table")
+        except Exception as e:
+            raise ValueError(
+                f"Change history table {self.change_history_table.fully_qualified} is missing the "
+                f"ERROR_MESSAGE column and schemachange was unable to add it automatically. "
+                f"Please run the following SQL manually with a role that has ALTER TABLE privileges:\n\n"
+                f"    ALTER TABLE {self.change_history_table.fully_qualified} "
+                f"ADD COLUMN IF NOT EXISTS ERROR_MESSAGE VARCHAR;\n\n"
+                f"Original error: {e}"
+            ) from e
 
     def record_change_history(
         self,
@@ -615,6 +668,7 @@ class SnowflakeSession:
         execution_time: int,
         status: str,
         logger: structlog.BoundLogger,
+        error_message: str = "",
     ) -> None:
         """
         Record a script execution in the change history table.
@@ -627,11 +681,13 @@ class SnowflakeSession:
             checksum: SHA-224 checksum of the rendered script content
             execution_time: Execution time in seconds
             status: Execution status (e.g., "Success")
+            error_message: Error message for failed scripts (optional)
             logger: Logger instance for this operation
         """
         if self.change_history_table is None:
             raise ValueError("change_history_table is required for deployment operations")
-
+        script_version = getattr(script, "version", "")
+        error_message = (error_message or "").replace("'", "''")
         query = f"""\
             INSERT INTO {self.change_history_table.fully_qualified} (
                 VERSION,
@@ -641,16 +697,18 @@ class SnowflakeSession:
                 CHECKSUM,
                 EXECUTION_TIME,
                 STATUS,
+                ERROR_MESSAGE,
                 INSTALLED_BY,
                 INSTALLED_ON
             ) VALUES (
-                '{getattr(script, "version", "")}',
+                '{script_version}',
                 '{script.description}',
                 '{script.name}',
                 '{script.type}',
                 '{checksum}',
                 {execution_time},
                 '{status}',
+                '{error_message}',
                 '{self.user}',
                 CURRENT_TIMESTAMP
             );

--- a/tests/session/test_SnowflakeSession.py
+++ b/tests/session/test_SnowflakeSession.py
@@ -7,6 +7,7 @@ from unittest import mock
 import pytest
 import snowflake.connector.errors
 import structlog
+from snowflake.connector.errors import ProgrammingError
 
 from schemachange.config.ChangeHistoryTable import ChangeHistoryTable
 from schemachange.ScriptExecutionError import ScriptExecutionError
@@ -63,6 +64,57 @@ class TestSnowflakeSession:
         result = session.fetch_change_history_metadata()
         assert result == {}
         assert session.con.execute_string.call_count == 1
+    def test_apply_change_script_failure_records_history(self, session: SnowflakeSession):
+        script = VersionedScript.from_path(Path("V1.0.0__test.sql"))
+        session.execute_snowflake_query = mock.Mock(side_effect=[Exception("boom"), None])
+        with (
+            mock.patch.object(session, "reset_session"),
+            mock.patch.object(session, "reset_query_tag"),
+            pytest.raises(ScriptExecutionError),
+        ):
+            session.apply_change_script(script, "select 1", False, session.logger)
+        assert session.execute_snowflake_query.call_count == 2
+        insert_query = session.execute_snowflake_query.call_args_list[1].args[0]
+        assert "Failed" in insert_query
+        assert "ERROR_MESSAGE" in insert_query
+        assert "boom" in insert_query
+
+    def test_validate_change_history_schema_column_exists(self, session: SnowflakeSession):
+        session.execute_snowflake_query = mock.Mock(return_value=[[]])
+        session.validate_change_history_schema(dry_run=False)
+        check_query = session.execute_snowflake_query.call_args_list[0].args[0]
+        assert "SELECT ERROR_MESSAGE" in check_query
+        assert "LIMIT 0" in check_query
+        assert session.execute_snowflake_query.call_count == 1
+
+    def test_validate_change_history_schema_missing_column_adds_it(self, session: SnowflakeSession):
+        session.execute_snowflake_query = mock.Mock(
+            side_effect=[ProgrammingError("invalid identifier 'ERROR_MESSAGE'", 0, 0), None]
+        )
+        session.validate_change_history_schema(dry_run=False)
+        assert session.execute_snowflake_query.call_count == 2
+        alter_stmt = session.execute_snowflake_query.call_args_list[1].args[0]
+        assert "ALTER TABLE" in alter_stmt
+        assert "ADD COLUMN" in alter_stmt
+        assert "ERROR_MESSAGE" in alter_stmt
+
+    def test_validate_change_history_schema_missing_column_no_privileges(self, session: SnowflakeSession):
+        session.execute_snowflake_query = mock.Mock(
+            side_effect=[
+                ProgrammingError("invalid identifier 'ERROR_MESSAGE'", 0, 0),
+                ProgrammingError("Insufficient privileges to operate on table", 0, 0),
+            ]
+        )
+        with pytest.raises(ValueError, match="Please run the following SQL manually"):
+            session.validate_change_history_schema(dry_run=False)
+
+    def test_validate_change_history_schema_dry_run_warns(self, session: SnowflakeSession):
+        session.execute_snowflake_query = mock.Mock(
+            side_effect=[ProgrammingError("invalid identifier 'ERROR_MESSAGE'", 0, 0)]
+        )
+        session.validate_change_history_schema(dry_run=True)
+        # Should not attempt ALTER in dry-run mode
+        assert session.execute_snowflake_query.call_count == 1
 
     def test_snowflake_session_with_additional_params_from_yaml_v2(self):
         """Test that additional_snowflake_params from YAML v2 are passed to connector."""

--- a/tests/session/test_SnowflakeSession.py
+++ b/tests/session/test_SnowflakeSession.py
@@ -65,6 +65,7 @@ class TestSnowflakeSession:
         result = session.fetch_change_history_metadata()
         assert result == {}
         assert session.con.execute_string.call_count == 1
+
     def test_apply_change_script_failure_records_history(self, session: SnowflakeSession):
         script = VersionedScript.from_path(Path("V1.0.0__test.sql"))
         session.execute_snowflake_query = mock.Mock(side_effect=[Exception("boom"), None])
@@ -116,6 +117,29 @@ class TestSnowflakeSession:
         session.validate_change_history_schema(dry_run=True)
         # Should not attempt ALTER in dry-run mode
         assert session.execute_snowflake_query.call_count == 1
+
+    def test_validate_change_history_schema_non_missing_column_error_propagates(self, session: SnowflakeSession):
+        # A ProgrammingError that is NOT an "invalid identifier" (e.g. wrong db/schema, permissions)
+        # must surface with its real root cause instead of being swallowed and misreported as a
+        # missing ERROR_MESSAGE column. No ALTER should be attempted.
+        session.execute_snowflake_query = mock.Mock(
+            side_effect=ProgrammingError("Insufficient privileges to operate on schema", 3001, 0)
+        )
+        with pytest.raises(ProgrammingError):
+            session.validate_change_history_schema(dry_run=False)
+        assert session.execute_snowflake_query.call_count == 1
+
+    def test_get_script_metadata_calls_validate_schema(self, session: SnowflakeSession):
+        # When the table already exists, get_script_metadata must validate the schema up front,
+        # forwarding the dry_run flag.
+        with (
+            mock.patch.object(session, "fetch_change_history_metadata", return_value={"last_altered": "2025-11-14"}),
+            mock.patch.object(session, "fetch_versioned_scripts", return_value=({}, None)),
+            mock.patch.object(session, "fetch_repeatable_scripts", return_value={}),
+            mock.patch.object(session, "validate_change_history_schema") as mock_validate,
+        ):
+            session.get_script_metadata(create_change_history_table=False, dry_run=True)
+        mock_validate.assert_called_once_with(dry_run=True)
 
     def test_snowflake_session_with_additional_params_from_yaml_v2(self):
         """Test that additional_snowflake_params from YAML v2 are passed to connector."""

--- a/tests/session/test_SnowflakeSession.py
+++ b/tests/session/test_SnowflakeSession.py
@@ -8,6 +8,7 @@ from unittest import mock
 import pytest
 import snowflake.connector.errors
 import structlog
+from snowflake.connector.errors import ProgrammingError
 
 from schemachange.config.ChangeHistoryTable import ChangeHistoryTable
 from schemachange.ScriptExecutionError import ScriptExecutionError
@@ -64,6 +65,57 @@ class TestSnowflakeSession:
         result = session.fetch_change_history_metadata()
         assert result == {}
         assert session.con.execute_string.call_count == 1
+    def test_apply_change_script_failure_records_history(self, session: SnowflakeSession):
+        script = VersionedScript.from_path(Path("V1.0.0__test.sql"))
+        session.execute_snowflake_query = mock.Mock(side_effect=[Exception("boom"), None])
+        with (
+            mock.patch.object(session, "reset_session"),
+            mock.patch.object(session, "reset_query_tag"),
+            pytest.raises(ScriptExecutionError),
+        ):
+            session.apply_change_script(script, "select 1", False, session.logger)
+        assert session.execute_snowflake_query.call_count == 2
+        insert_query = session.execute_snowflake_query.call_args_list[1].args[0]
+        assert "Failed" in insert_query
+        assert "ERROR_MESSAGE" in insert_query
+        assert "boom" in insert_query
+
+    def test_validate_change_history_schema_column_exists(self, session: SnowflakeSession):
+        session.execute_snowflake_query = mock.Mock(return_value=[[]])
+        session.validate_change_history_schema(dry_run=False)
+        check_query = session.execute_snowflake_query.call_args_list[0].args[0]
+        assert "SELECT ERROR_MESSAGE" in check_query
+        assert "LIMIT 0" in check_query
+        assert session.execute_snowflake_query.call_count == 1
+
+    def test_validate_change_history_schema_missing_column_adds_it(self, session: SnowflakeSession):
+        session.execute_snowflake_query = mock.Mock(
+            side_effect=[ProgrammingError("invalid identifier 'ERROR_MESSAGE'", 0, 0), None]
+        )
+        session.validate_change_history_schema(dry_run=False)
+        assert session.execute_snowflake_query.call_count == 2
+        alter_stmt = session.execute_snowflake_query.call_args_list[1].args[0]
+        assert "ALTER TABLE" in alter_stmt
+        assert "ADD COLUMN" in alter_stmt
+        assert "ERROR_MESSAGE" in alter_stmt
+
+    def test_validate_change_history_schema_missing_column_no_privileges(self, session: SnowflakeSession):
+        session.execute_snowflake_query = mock.Mock(
+            side_effect=[
+                ProgrammingError("invalid identifier 'ERROR_MESSAGE'", 0, 0),
+                ProgrammingError("Insufficient privileges to operate on table", 0, 0),
+            ]
+        )
+        with pytest.raises(ValueError, match="Please run the following SQL manually"):
+            session.validate_change_history_schema(dry_run=False)
+
+    def test_validate_change_history_schema_dry_run_warns(self, session: SnowflakeSession):
+        session.execute_snowflake_query = mock.Mock(
+            side_effect=[ProgrammingError("invalid identifier 'ERROR_MESSAGE'", 0, 0)]
+        )
+        session.validate_change_history_schema(dry_run=True)
+        # Should not attempt ALTER in dry-run mode
+        assert session.execute_snowflake_query.call_count == 1
 
     def test_snowflake_session_with_additional_params_from_yaml_v2(self):
         """Test that additional_snowflake_params from YAML v2 are passed to connector."""


### PR DESCRIPTION
## Summary

- Adds `ERROR_MESSAGE VARCHAR` to the `CREATE TABLE` statement so newly created change history tables include the column from the start
- Adds `validate_change_history_schema()` called at initialization (after the table is confirmed to exist, before any scripts run), using a fast metadata-only `SELECT ERROR_MESSAGE FROM <table> LIMIT 0` check
- If the column is missing on an existing table (created by an older version of schemachange or manually by a DBA): schemachange attempts `ALTER TABLE ... ADD COLUMN IF NOT EXISTS ERROR_MESSAGE VARCHAR` automatically
- If the role lacks ALTER privileges, the deploy fails immediately with a clear message showing the exact SQL to run manually — no mid-deploy surprises
- In dry-run mode, a warning is logged if the column is missing but no ALTER is attempted
- Removes the previous runtime try/except hack in `record_change_history` that added the column on INSERT failure

## Motivation

Previously, `ERROR_MESSAGE` was added via auto-ALTER when an INSERT failed at runtime. This was risky: it introduced DDL mid-deploy, and if the role lacked ALTER privileges the deploy would break even for successful scripts (since `error_message=''` is always passed). Moving this check to initialization gives a predictable, upfront failure instead.

This is a prerequisite for the continue-on-error feature (#339).