### PR TITLE
feat: add schemachange-no-jinja marker to skip jinja rendering per script

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ schemachange will replace any variable placeholders before running your change s
 finds any variable placeholders that haven't been replaced.
 
 If a script contains jinja-style syntax that should not be processed by schemachange, add the comment
-`--schemachange-no-jinja` anywhere in the file. When this marker is present, schemachange will skip jinja rendering for
+`-- schemachange-no-jinja` anywhere in the file. When this marker is present, schemachange will skip jinja rendering for
 that script and execute it as-is.
 
 #### Secrets filtering

--- a/README.md
+++ b/README.md
@@ -349,6 +349,10 @@ JSON object formatted as a string.
 schemachange will replace any variable placeholders before running your change script code and will throw an error if it
 finds any variable placeholders that haven't been replaced.
 
+If a script contains jinja-style syntax that should not be processed by schemachange, add the comment
+`-- schemachange-no-jinja` anywhere in the file. When this marker is present, schemachange will skip jinja rendering for
+that script and execute it as-is.
+
 #### Secrets filtering
 
 While many CI/CD tools already have the capability to filter secrets, it is best that any tool also does not output

--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ schemachange will replace any variable placeholders before running your change s
 finds any variable placeholders that haven't been replaced.
 
 If a script contains jinja-style syntax that should not be processed by schemachange, add the comment
-`-- schemachange-no-jinja` anywhere in the file. When this marker is present, schemachange will skip jinja rendering for
+`--schemachange-no-jinja` anywhere in the file. When this marker is present, schemachange will skip jinja rendering for
 that script and execute it as-is.
 
 #### Secrets filtering

--- a/README.md
+++ b/README.md
@@ -349,9 +349,10 @@ JSON object formatted as a string.
 schemachange will replace any variable placeholders before running your change script code and will throw an error if it
 finds any variable placeholders that haven't been replaced.
 
-If a script contains jinja-style syntax that should not be processed by schemachange, add the comment
-`-- schemachange-no-jinja` anywhere in the file. When this marker is present, schemachange will skip jinja rendering for
-that script and execute it as-is.
+If a script contains jinja-style syntax that should not be processed by schemachange, add the marker
+`schemachange-no-jinja` in a SQL line comment (e.g. `-- schemachange-no-jinja`). When this marker is present,
+schemachange skips jinja rendering for that script and executes it as-is. The marker is case-insensitive and only
+recognized in a `--` line comment, so the token inside a string literal or block comment does not disable jinja.
 
 #### Secrets filtering
 

--- a/schemachange/JinjaTemplateProcessor.py
+++ b/schemachange/JinjaTemplateProcessor.py
@@ -13,6 +13,8 @@ from schemachange.JinjaEnvVar import JinjaEnvVar
 
 logger = structlog.getLogger(__name__)
 
+_NO_JINJA_MARKER = "schemachange-no-jinja"
+
 
 class JinjaTemplateProcessor:
     _env_args = {
@@ -52,8 +54,17 @@ class JinjaTemplateProcessor:
             variables = {}
         # jinja needs posix path
         posix_path = Path(script).as_posix()
-        template = self.__environment.get_template(posix_path)
-        raw_content = template.render(**variables)
+        raw_content = None
+        try:
+            source, _, _ = self.__environment.loader.get_source(self.__environment, posix_path)
+            if _NO_JINJA_MARKER in source.lower():
+                raw_content = source
+        except Exception:
+            raw_content = None
+
+        if raw_content is None:
+            template = self.__environment.get_template(posix_path)
+            raw_content = template.render(**variables)
 
         # Remove UTF-8 BOM if present (issue #250)
         # The BOM character (\ufeff) causes errors

--- a/schemachange/JinjaTemplateProcessor.py
+++ b/schemachange/JinjaTemplateProcessor.py
@@ -54,15 +54,10 @@ class JinjaTemplateProcessor:
             variables = {}
         # jinja needs posix path
         posix_path = Path(script).as_posix()
-        raw_content = None
-        try:
-            source, _, _ = self.__environment.loader.get_source(self.__environment, posix_path)
-            if _NO_JINJA_MARKER in source.lower():
-                raw_content = source
-        except Exception:
-            raw_content = None
-
-        if raw_content is None:
+        source, _, _ = self.__environment.loader.get_source(self.__environment, posix_path)
+        if _NO_JINJA_MARKER in source.lower():
+            raw_content = source
+        else:
             template = self.__environment.get_template(posix_path)
             raw_content = template.render(**variables)
 

--- a/schemachange/JinjaTemplateProcessor.py
+++ b/schemachange/JinjaTemplateProcessor.py
@@ -13,7 +13,11 @@ from schemachange.JinjaEnvVar import JinjaEnvVar
 
 logger = structlog.getLogger(__name__)
 
-_NO_JINJA_MARKER = "schemachange-no-jinja"
+# A script opts out of Jinja rendering with a line-comment marker, e.g.
+#   -- schemachange-no-jinja
+# Scoped to SQL line comments so the token inside a string literal or a
+# block comment does NOT trigger a false positive.
+_NO_JINJA_PATTERN = re.compile(r"--[^\n]*schemachange-no-jinja", re.IGNORECASE)
 
 
 class JinjaTemplateProcessor:
@@ -55,10 +59,11 @@ class JinjaTemplateProcessor:
         # jinja needs posix path
         posix_path = Path(script).as_posix()
         source, _, _ = self.__environment.loader.get_source(self.__environment, posix_path)
-        if _NO_JINJA_MARKER in source.lower():
+        if _NO_JINJA_PATTERN.search(source):
+            logger.debug("Skipping Jinja rendering (schemachange-no-jinja marker)", script=script)
             raw_content = source
         else:
-            template = self.__environment.get_template(posix_path)
+            template = self.__environment.from_string(source)
             raw_content = template.render(**variables)
 
         # Remove UTF-8 BOM if present (issue #250)

--- a/tests/test_JinjaTemplateProcessor.py
+++ b/tests/test_JinjaTemplateProcessor.py
@@ -107,6 +107,21 @@ class TestJinjaTemplateProcessor:
 
         assert context == "-- schemachange-no-jinja\nselect '{{ should_ignore }}'"
 
+    def test_render_raises_on_undefined_variable_without_marker(self, processor: JinjaTemplateProcessor):
+        templates = {"test.sql": "select '{{ should_ignore }}'"}
+        processor.override_loader(DictLoader(templates))
+
+        with pytest.raises(UndefinedError):
+            processor.render("test.sql", {})
+
+    def test_render_substitutes_variable_without_marker(self, processor: JinjaTemplateProcessor):
+        templates = {"test.sql": "select '{{ my_var }}'"}
+        processor.override_loader(DictLoader(templates))
+
+        context = processor.render("test.sql", {"my_var": "hello"})
+
+        assert context == "select 'hello'"
+
     # ============================================================
     # Empty content validation tests - issue #258
     # ============================================================

--- a/tests/test_JinjaTemplateProcessor.py
+++ b/tests/test_JinjaTemplateProcessor.py
@@ -100,12 +100,12 @@ class TestJinjaTemplateProcessor:
         assert context == "some text myvar_default"
 
     def test_render_ignores_jinja_when_marker_present(self, processor: JinjaTemplateProcessor):
-        templates = {"test.sql": "-- schemachange-no-jinja\nselect '{{ should_ignore }}'"}
+        templates = {"test.sql": "--schemachange-no-jinja\nselect '{{ should_ignore }}'"}
         processor.override_loader(DictLoader(templates))
 
         context = processor.render("test.sql", {"should_ignore": "replacement"})
 
-        assert context == "-- schemachange-no-jinja\nselect '{{ should_ignore }}'"
+        assert context == "--schemachange-no-jinja\nselect '{{ should_ignore }}'"
 
     def test_render_raises_on_undefined_variable_without_marker(self, processor: JinjaTemplateProcessor):
         templates = {"test.sql": "select '{{ should_ignore }}'"}

--- a/tests/test_JinjaTemplateProcessor.py
+++ b/tests/test_JinjaTemplateProcessor.py
@@ -99,6 +99,14 @@ class TestJinjaTemplateProcessor:
 
         assert context == "some text myvar_default"
 
+    def test_render_ignores_jinja_when_marker_present(self, processor: JinjaTemplateProcessor):
+        templates = {"test.sql": "-- schemachange-no-jinja\nselect '{{ should_ignore }}'"}
+        processor.override_loader(DictLoader(templates))
+
+        context = processor.render("test.sql", {"should_ignore": "replacement"})
+
+        assert context == "-- schemachange-no-jinja\nselect '{{ should_ignore }}'"
+
     # ============================================================
     # Empty content validation tests - issue #258
     # ============================================================

--- a/tests/test_JinjaTemplateProcessor.py
+++ b/tests/test_JinjaTemplateProcessor.py
@@ -100,12 +100,12 @@ class TestJinjaTemplateProcessor:
         assert context == "some text myvar_default"
 
     def test_render_ignores_jinja_when_marker_present(self, processor: JinjaTemplateProcessor):
-        templates = {"test.sql": "--schemachange-no-jinja\nselect '{{ should_ignore }}'"}
+        templates = {"test.sql": "-- schemachange-no-jinja\nselect '{{ should_ignore }}'"}
         processor.override_loader(DictLoader(templates))
 
         context = processor.render("test.sql", {"should_ignore": "replacement"})
 
-        assert context == "--schemachange-no-jinja\nselect '{{ should_ignore }}'"
+        assert context == "-- schemachange-no-jinja\nselect '{{ should_ignore }}'"
 
     def test_render_raises_on_undefined_variable_without_marker(self, processor: JinjaTemplateProcessor):
         templates = {"test.sql": "select '{{ should_ignore }}'"}

--- a/tests/test_JinjaTemplateProcessor.py
+++ b/tests/test_JinjaTemplateProcessor.py
@@ -122,6 +122,25 @@ class TestJinjaTemplateProcessor:
 
         assert context == "select 'hello'"
 
+    def test_marker_in_string_literal_does_not_skip_jinja(self, processor: JinjaTemplateProcessor):
+        """The token inside a string literal must NOT disable Jinja (no false positive)."""
+        templates = {
+            "test.sql": "update config set value = 'schemachange-no-jinja' where env = '{{ my_var }}'",
+        }
+        processor.override_loader(DictLoader(templates))
+
+        context = processor.render("test.sql", {"my_var": "prod"})
+
+        assert context == "update config set value = 'schemachange-no-jinja' where env = 'prod'"
+
+    def test_marker_is_case_insensitive(self, processor: JinjaTemplateProcessor):
+        templates = {"test.sql": "-- SchemaChange-No-Jinja\nselect '{{ should_ignore }}'"}
+        processor.override_loader(DictLoader(templates))
+
+        context = processor.render("test.sql", {"should_ignore": "replacement"})
+
+        assert context == "-- SchemaChange-No-Jinja\nselect '{{ should_ignore }}'"
+
     # ============================================================
     # Empty content validation tests - issue #258
     # ============================================================


### PR DESCRIPTION
## Summary

- Adds a `-- schemachange-no-jinja` marker: when present anywhere in a script file, schemachange skips jinja rendering entirely and executes the file as-is
- Useful for scripts that contain jinja-style syntax (e.g. `{{ }}`) that should be passed through to Snowflake rather than processed by schemachange
- No changes to behavior for scripts without the marker