### PR TITLE
Update structlog version requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "jinja2~=3.0",
     "pyyaml~=6.0",
     "snowflake-connector-python>=3.0,<5.0",
-    "structlog~=24.1.0",
+    "structlog>=24.1.0,<26.0",
     "colorama; platform_system == 'Windows'",
 ]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ install_requires =
     jinja2~=3.0
     pyyaml~=6.0
     snowflake-connector-python>=3.0,<5.0
-    structlog~=24.1.0
+    structlog>=24.1.0,<26.0
 python_requires = >=3.10
 include_package_data = True
 


### PR DESCRIPTION
## What does this PR do?

Update structlog version requirements to use 24.x or 25.x 

## Checklist

- [x] Tests pass locally (`pytest`)
- [x] Code is formatted (`ruff format .`)