### PR TITLE
Fix typos and standardize 'environment variable' wording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -211,7 +211,7 @@ All notable changes to this project will be documented in this file.
 - Added support for Oauth and external browser and Okta authentication methods.
 - Added `--oauth-config` to accept values for oauth configuration.
 ### Changed
-- Inverted Program Call sequence and refactored all snowflake interactions into a Class. Class now persists connection accross all interactions and updates the snowflake query tag session variable as scripts are executed.
+- Inverted Program Call sequence and refactored all snowflake interactions into a Class. Class now persists connection across all interactions and updates the snowflake query tag session variable as scripts are executed.
 - Cleaned up argument passing and other repetitive code using dictionary and set comparisons for easy maintenance. (Converted variable names to a consistent snake_case from a mix of kebab-case and snake_case)
 - Fixed change history table processing to allow mixed case names when '"' are used in the name.
 - Moved most error, log and warning messages and query strings to global or class variables.
@@ -252,7 +252,7 @@ All notable changes to this project will be documented in this file.
 ## [3.3.0] - 2021-11-06
 ### Added
 - Added processing of schemachange-config.yml with jinja templating engine.
-  - Included new Jinja function env_var for accessing environmental variables from the config file.
+  - Included new Jinja function env_var for accessing environment variables from the config file.
 
 ## [3.2.2] - 2021-11-06
 ### Added
@@ -413,5 +413,5 @@ All notable changes to this project will be documented in this file.
 - Updated the getting started section of the README.md to make the getting started steps more clear
 
 ### Removed
-- The ability for snowchange to create user databases directly (now the user must explicity do so in their change scripts)
+- The ability for snowchange to create user databases directly (now the user must explicitly do so in their change scripts)
 - The `--environment-name` and `--append-environment-name` parameters

--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ finds any variable placeholders that haven't been replaced.
 
 While many CI/CD tools already have the capability to filter secrets, it is best that any tool also does not output
 secrets to the console or logs. Schemachange implements secrets filtering in a number of areas to ensure secrets are not
-writen to the console or logs. The only exception is the `render` command which will display secrets.
+written to the console or logs. The only exception is the `render` command which will display secrets.
 
 A secret is just a standard variable that has been tagged as a secret. This is determined using a naming convention and
 either of the following will tag a variable as a secret:
@@ -412,7 +412,7 @@ For detailed troubleshooting and solutions, see [TROUBLESHOOTING.md](TROUBLESHOO
 
 schemachange records all applied changes scripts to the change history table. By default, schemachange will attempt to
 log all activities to the `METADATA.SCHEMACHANGE.CHANGE_HISTORY` table. The name and location of the change history
-table can be overriden via a command line argument (`-c`, `--schemachange-change-history-table`, or `--change-history-table`)
+table can be overridden via a command line argument (`-c`, `--schemachange-change-history-table`, or `--change-history-table`)
 or the `schemachange-config.yml` file (`change-history-table`). The value passed to the parameter can have a one, two, or
 three part name (e.g. "TABLE_NAME", or "SCHEMA_NAME.TABLE_NAME", or "DATABASE_NAME.SCHEMA_NAME.TABLE_NAME"). This can be
 used to support multiple environments (dev, test, prod) or multiple subject areas within the same Snowflake account.
@@ -928,15 +928,15 @@ This behavior ensures:
 
 ##### env_var
 
-Provides access to environmental variables. The function can be used two different ways.
+Provides access to environment variables. The function can be used two different ways.
 
-Return the value of the environmental variable if it exists, otherwise return the default value.
+Return the value of the environment variable if it exists, otherwise return the default value.
 
 ```jinja
 {{ env_var('<environmental_variable>', 'default') }}
 ```
 
-Return the value of the environmental variable if it exists, otherwise raise an error.
+Return the value of the environment variable if it exists, otherwise raise an error.
 
 ```jinja
 {{ env_var('<environmental_variable>') }}

--- a/schemachange/JinjaEnvVar.py
+++ b/schemachange/JinjaEnvVar.py
@@ -7,7 +7,7 @@ import jinja2.ext
 
 class JinjaEnvVar(jinja2.ext.Extension):
     """
-    Extends Jinja Templates with access to environmental variables
+    Extends Jinja Templates with access to environment variables
     """
 
     def __init__(self, environment: jinja2.Environment):
@@ -19,13 +19,13 @@ class JinjaEnvVar(jinja2.ext.Extension):
     @staticmethod
     def env_var(env_var: str, default: str | None = None) -> str:
         """
-        Returns the value of the environmental variable or the default.
+        Returns the value of the environment variable or the default.
         """
         result = default
         if env_var in os.environ:
             result = os.environ[env_var]
 
         if result is None:
-            raise ValueError(f"Could not find environmental variable {env_var} and no default value was provided")
+            raise ValueError(f"Could not find environment variable {env_var} and no default value was provided")
 
         return result

--- a/schemachange/config/utils.py
+++ b/schemachange/config/utils.py
@@ -258,7 +258,7 @@ def load_yaml_config(config_file_path: Path | None) -> dict[str, Any]:
     # First read in the yaml config file, if present
     if config_file_path is not None and config_file_path.is_file():
         with config_file_path.open() as config_file:
-            # Run the config file through the jinja engine to give access to environmental variables
+            # Run the config file through the jinja engine to give access to environment variables
             # The config file does not have the same access to the jinja functionality that a script
             # has.
             config_template = jinja2.Template(

--- a/tests/config/test_get_yaml_config.py
+++ b/tests/config/test_get_yaml_config.py
@@ -67,7 +67,7 @@ vars:
 
     with pytest.raises(ValueError) as e:
         load_yaml_config(config_file)
-    assert str(e.value) == "Could not find environmental variable TEST_VAR and no default value was provided"
+    assert str(e.value) == "Could not find environment variable TEST_VAR and no default value was provided"
 
 
 @mock.patch("pathlib.Path.is_dir", return_value=True)

--- a/tests/test_JinjaEnvVar.py
+++ b/tests/test_JinjaEnvVar.py
@@ -15,7 +15,7 @@ def test_env_var_with_no_default_and_no_environmental_variables_should_raise_exc
 
     with pytest.raises(ValueError) as e:
         JinjaEnvVar.env_var("SF_DATABASE")
-    assert str(e.value) == "Could not find environmental variable SF_DATABASE and no default value was provided"
+    assert str(e.value) == "Could not find environment variable SF_DATABASE and no default value was provided"
 
 
 @mock.patch.dict(os.environ, {}, clear=True)

--- a/tests/test_JinjaTemplateProcessor.py
+++ b/tests/test_JinjaTemplateProcessor.py
@@ -29,7 +29,7 @@ class TestJinjaTemplateProcessor:
     def test_render_simple_string_expecting_variable_that_does_not_exist_should_raise_exception(
         self, processor: JinjaTemplateProcessor
     ):
-        # overide the default loader
+        # override the default loader
         templates = {"test.sql": "some text {{ myvar }}"}
         processor.override_loader(DictLoader(templates))
 
@@ -39,7 +39,7 @@ class TestJinjaTemplateProcessor:
         assert str(e.value) == "'myvar' is undefined"
 
     def test_render_simple_string_expecting_variable(self, processor: JinjaTemplateProcessor):
-        # overide the default loader
+        # override the default loader
         templates = {"test.sql": "Hello {{ myvar }}!"}
         processor.override_loader(DictLoader(templates))
 
@@ -66,20 +66,20 @@ class TestJinjaTemplateProcessor:
         assert context == "Hello world!"
 
     def test_from_environ_not_set(self, processor: JinjaTemplateProcessor):
-        # overide the default loader
+        # override the default loader
         templates = {"test.sql": "some text {{ env_var('MYVAR') }}"}
         processor.override_loader(DictLoader(templates))
 
         with pytest.raises(ValueError) as e:
             processor.render("test.sql", None)
 
-        assert str(e.value) == "Could not find environmental variable MYVAR and no default value was provided"
+        assert str(e.value) == "Could not find environment variable MYVAR and no default value was provided"
 
     def test_from_environ_set(self, processor: JinjaTemplateProcessor):
         # set MYVAR env variable
         os.environ["MYVAR"] = "myvar_from_environment"
 
-        # overide the default loader
+        # override the default loader
         templates = {"test.sql": "some text {{ env_var('MYVAR') }}"}
         processor.override_loader(DictLoader(templates))
 
@@ -91,7 +91,7 @@ class TestJinjaTemplateProcessor:
         assert context == "some text myvar_from_environment"
 
     def test_from_environ_not_set_default(self, processor: JinjaTemplateProcessor):
-        # overide the default loader
+        # override the default loader
         templates = {"test.sql": "some text {{ env_var('MYVAR', 'myvar_default') }}"}
         processor.override_loader(DictLoader(templates))
 


### PR DESCRIPTION
## What does this PR do?

### Minor typo fixes

- writen → written, overriden → overridden (README)
- accross → across, explicity → explicitly (CHANGELOG)
- overide → override (test comments)
- environmental variable → environment variable (code, tests, docs)

The error string in JinjaEnvVar.py changes from "environmental variable"
to "environment variable" — tests updated atomically.