### PR TITLE
fix: normalize unquoted identifiers to uppercase

### DIFF
--- a/schemachange/config/ChangeHistoryTable.py
+++ b/schemachange/config/ChangeHistoryTable.py
@@ -4,6 +4,19 @@ from typing import ClassVar
 from schemachange.config.utils import get_snowflake_identifier_string
 
 
+def _normalize_identifier(value: str) -> str:
+    """Uppercase unquoted identifiers to match Snowflake's INFORMATION_SCHEMA storage.
+
+    Snowflake stores unquoted identifiers in uppercase in metadata catalogs.
+    Quoted identifiers (e.g. "mySchema") are case-sensitive and left as-is.
+
+    Fixes: https://github.com/Snowflake-Labs/schemachange/issues/432
+    """
+    if value and not (value.startswith('"') and value.endswith('"')):
+        return value.upper()
+    return value
+
+
 @dataclasses.dataclass(frozen=True)
 class ChangeHistoryTable:
     _default_database_name: ClassVar[str] = "METADATA"
@@ -43,7 +56,13 @@ class ChangeHistoryTable:
                 raise ValueError(f"Invalid change history table name: {table_str}")
 
         return cls(
-            table_name=get_snowflake_identifier_string(input_value=table_name, input_type="table_name"),
-            schema_name=get_snowflake_identifier_string(input_value=schema_name, input_type="schema_name"),
-            database_name=get_snowflake_identifier_string(input_value=database_name, input_type="database_name"),
+            table_name=_normalize_identifier(
+                get_snowflake_identifier_string(input_value=table_name, input_type="table_name")
+            ),
+            schema_name=_normalize_identifier(
+                get_snowflake_identifier_string(input_value=schema_name, input_type="schema_name")
+            ),
+            database_name=_normalize_identifier(
+                get_snowflake_identifier_string(input_value=database_name, input_type="database_name")
+            ),
         )

--- a/tests/test_cli_misc.py
+++ b/tests/test_cli_misc.py
@@ -82,23 +82,23 @@ def test_sorted_alphanumeric_mixed_string():
             {
                 "database_name": ChangeHistoryTable._default_database_name,
                 "schema_name": ChangeHistoryTable._default_schema_name,
-                "table_name": "change_history_table",
+                "table_name": "CHANGE_HISTORY_TABLE",
             },
         ),
         (
             "myschema.change_history_table",
             {
                 "database_name": ChangeHistoryTable._default_database_name,
-                "schema_name": "myschema",
-                "table_name": "change_history_table",
+                "schema_name": "MYSCHEMA",
+                "table_name": "CHANGE_HISTORY_TABLE",
             },
         ),
         (
             "mydb.myschema.change_history_table",
             {
-                "database_name": "mydb",
-                "schema_name": "myschema",
-                "table_name": "change_history_table",
+                "database_name": "MYDB",
+                "schema_name": "MYSCHEMA",
+                "table_name": "CHANGE_HISTORY_TABLE",
             },
         ),
         (

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -139,9 +139,9 @@ deploy_all_cli_arg_names = pytest.param(
         "snowflake_database": get_snowflake_identifier_string("snowflake-database-from-cli", "placeholder"),
         "snowflake_schema": get_snowflake_identifier_string("snowflake-schema-from-cli", "placeholder"),
         "change_history_table": ChangeHistoryTable(
-            database_name="db",
-            schema_name="schema",
-            table_name="table_from_cli",
+            database_name="DB",
+            schema_name="SCHEMA",
+            table_name="TABLE_FROM_CLI",
         ),
         "config_vars": {
             "var1": "from_cli",
@@ -212,9 +212,9 @@ deploy_all_cli_arg_flags = pytest.param(
         "snowflake_database": get_snowflake_identifier_string("snowflake-database-from-cli", "placeholder"),
         "snowflake_schema": get_snowflake_identifier_string("snowflake-schema-from-cli", "placeholder"),
         "change_history_table": ChangeHistoryTable(
-            database_name="db",
-            schema_name="schema",
-            table_name="table_from_cli",
+            database_name="DB",
+            schema_name="SCHEMA",
+            table_name="TABLE_FROM_CLI",
         ),
         "config_vars": {
             "var1": "from_cli",
@@ -285,9 +285,9 @@ deploy_all_env_all_cli = pytest.param(
         "snowflake_database": get_snowflake_identifier_string("snowflake-database-from-cli", "placeholder"),
         "snowflake_schema": get_snowflake_identifier_string("snowflake-schema-from-cli", "placeholder"),
         "change_history_table": ChangeHistoryTable(
-            database_name="db",
-            schema_name="schema",
-            table_name="table_from_cli",
+            database_name="DB",
+            schema_name="SCHEMA",
+            table_name="TABLE_FROM_CLI",
         ),
         "config_vars": {
             "var1": "from_cli",


### PR DESCRIPTION
## What does this PR do?

Unquoted identifiers in change-history-table config (e.g. mydb.myschema.mytable) were compared case-sensitively against INFORMATION_SCHEMA, which stores names in uppercase. This caused R__ scripts to be re-applied on every deploy when the config used lowercase.

Added ```_normalize_identifier()``` to ChangeHistoryTable.py that uppercases unquoted identifiers while preserving quoted ones. Updated the tests to reflect correct Snowflake identifier semantics.

Closes #432

## Checklist

- [X] Tests pass locally (`pytest`)
- [X] Code is formatted (`ruff format .`)
