### PR TITLE
Adding multi line comment feature

### DIFF
--- a/schemachange/LocalDataInjection.py
+++ b/schemachange/LocalDataInjection.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import csv
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import jinja2.ext
+import yaml
+
+
+class LocalDataInjection(jinja2.ext.Extension):
+    """
+    Extends Jinja Templates with access to environmental variables and local data files
+    """
+
+    def __init__(self, environment: jinja2.Environment):
+        super().__init__(environment)
+
+        # add globals
+        environment.globals["env_var"] = LocalDataInjection.env_var
+        environment.globals["from_csv"] = LocalDataInjection.from_csv
+        environment.globals["from_json"] = LocalDataInjection.from_json
+        environment.globals["from_yaml"] = LocalDataInjection.from_yaml
+
+    @staticmethod
+    def env_var(env_var: str, default: str | None = None) -> str:
+        """
+        Returns the value of the environmental variable or the default.
+        """
+        result = default
+        if env_var in os.environ:
+            result = os.environ[env_var]
+
+        if result is None:
+            raise ValueError(f"Could not find environmental variable {env_var} and no default value was provided")
+
+        return result
+
+    @staticmethod
+    def from_csv(
+        file_path: str,
+        as_dict: bool = False,
+        delimiter: str = ",",
+        encoding: str = "utf-8",
+    ) -> list[tuple | dict[str, Any]]:
+        """
+        Loads data from a CSV file and returns it as a list of tuples or dictionaries.
+
+        Args:
+            file_path: Path to the CSV file
+            as_dict: If True, returns list of dictionaries. If False, returns list of tuples
+            delimiter: CSV delimiter character
+            encoding: File encoding
+
+        Returns:
+            List of tuples or dictionaries representing CSV data
+        """
+        csv_path = Path(file_path)
+        if not csv_path.exists():
+            raise FileNotFoundError(f"CSV file not found: {file_path}")
+
+        data = []
+
+        with open(csv_path, encoding=encoding) as csvfile:
+            if as_dict:
+                reader = csv.DictReader(csvfile, delimiter=delimiter)
+                data = [dict(row) for row in reader]
+            else:
+                reader = csv.reader(csvfile, delimiter=delimiter)
+                data = [tuple(row) for row in reader]
+
+        return data
+
+    @staticmethod
+    def from_json(file_path: str, encoding: str = "utf-8") -> dict[str, Any] | list[Any]:
+        """
+        Loads data from a JSON file and returns it as a dictionary or list.
+
+        Args:
+            file_path: Path to the JSON file
+            encoding: File encoding
+
+        Returns:
+            Dictionary or list representing JSON data
+        """
+        json_path = Path(file_path)
+        if not json_path.exists():
+            raise FileNotFoundError(f"JSON file not found: {file_path}")
+
+        with open(json_path, encoding=encoding) as jsonfile:
+            data = json.load(jsonfile)
+
+        return data
+
+    @staticmethod
+    def from_yaml(file_path: str, encoding: str = "utf-8") -> dict[str, Any] | list[Any]:
+        """
+        Loads data from a YAML file and returns it as a dictionary or list.
+
+        Args:
+            file_path: Path to the YAML file
+            encoding: File encoding
+
+        Returns:
+            Dictionary or list representing YAML data
+        """
+        yaml_path = Path(file_path)
+        if not yaml_path.exists():
+            raise FileNotFoundError(f"YAML file not found: {file_path}")
+
+        with open(yaml_path, encoding=encoding) as yamlfile:
+            data = yaml.safe_load(yamlfile)
+
+        return data

--- a/schemachange/session/SnowflakeSession.py
+++ b/schemachange/session/SnowflakeSession.py
@@ -19,6 +19,7 @@ from schemachange.session.Script import (
     VersionedCLIScript,
     VersionedScript,
 )
+from schemachange.sql_splitter import split_sql_statements
 from schemachange.version import max_alphanumeric
 
 
@@ -215,10 +216,17 @@ class SnowflakeSession:
         )
 
         try:
-            res = self.con.execute_string(query)
+            statements = split_sql_statements(query)
+            res = []
+            for stmt in statements:
+                result = self.con.execute_string(stmt)
+                if isinstance(result, list):
+                    res.extend(result)
+                else:
+                    res.append(result)
             if not self.autocommit:
                 self.con.commit()
-            logger.debug("Query executed")
+            logger.debug("Query executed", statement_count=len(statements))
             return res
 
         except snowflake.connector.errors.ProgrammingError as e:

--- a/schemachange/sql_splitter.py
+++ b/schemachange/sql_splitter.py
@@ -1,0 +1,332 @@
+"""BEGIN/END-aware SQL statement splitter for schemachange.
+
+Replaces the Snowflake Python connector's `execute_string()` splitting,
+which naively splits on semicolons and breaks multi-statement blocks like
+stored procedures, tasks, and anonymous blocks that use BEGIN...END without
+dollar-quoting.
+
+This module provides a `split_sql_statements()` function that respects:
+- $$ ... $$ dollar-quoted blocks (same as connector)
+- Single and double-quoted strings (same as connector)
+- -- and /* */ comments (same as connector)
+- BEGIN...END block nesting (NEW — the gap this fills)
+- DECLARE...BEGIN pattern for anonymous blocks and procedures
+"""
+
+import re
+from collections.abc import Iterator
+
+# Keywords that precede a scripting BEGIN (not BEGIN TRANSACTION/WORK).
+# Validated against Snowflake Scripting documentation:
+#   AS    - CREATE PROCEDURE/FUNCTION ... AS BEGIN
+#   DO    - FOR ... DO BEGIN ... END; / WHILE ... DO BEGIN ... END;
+#   THEN  - IF condition THEN BEGIN ... END;
+#   ELSE  - ELSE BEGIN ... END;
+#   LOOP  - LOOP BEGIN ... END; END LOOP; (unusual but valid)
+_BLOCK_OPENERS = frozenset({"AS", "DO", "THEN", "ELSE", "LOOP"})
+
+# BEGIN TRANSACTION / BEGIN WORK are standalone statements, not block openers.
+# Snowflake docs explicitly warn about this ambiguity.
+_BEGIN_TRANSACTION_RE = re.compile(r"\bBEGIN\s+(TRANSACTION|WORK)\b", re.IGNORECASE)
+
+# END followed by these keywords closes a compound structure, NOT a BEGIN block.
+# These should not decrement begin_depth.
+# Full list from Snowflake docs:
+#   END IF, END FOR, END LOOP, END WHILE, END CASE, END REPEAT
+_COMPOUND_END_RE = re.compile(r"\bEND\s+(IF|LOOP|FOR|WHILE|CASE|REPEAT)\b", re.IGNORECASE)
+
+
+def split_sql_statements(sql_text: str) -> list[str]:
+    """Split SQL text into individual statements, respecting BEGIN...END blocks.
+
+    Returns a list of SQL statement strings (stripped, non-empty).
+    """
+    return list(_split_iter(sql_text))
+
+
+def _split_iter(sql_text: str) -> Iterator[str]:
+    """Iterate over SQL statements in the input text.
+
+    This is a character-by-character state machine. At any point, the scanner
+    is in exactly one state:
+      - Normal mode (checking for transitions)
+      - Inside a single-quoted string
+      - Inside a double-quoted identifier
+      - Inside a $$ dollar-quoted block
+      - Inside a -- line comment
+      - Inside a /* block comment
+
+    In normal mode, it also tracks `begin_depth` — how many BEGIN...END blocks
+    we're nested inside. Semicolons only cause a statement split when depth == 0.
+    """
+    pos = 0
+    length = len(sql_text)
+    statement_start = 0
+    begin_depth = 0
+    in_declare_block = False  # Tracks DECLARE...BEGIN pattern
+
+    # State flags — exactly one is True at a time (or all False = normal mode)
+    in_single_quote = False
+    in_double_quote = False
+    in_dollar_quote = False
+    in_line_comment = False
+    in_block_comment = False
+
+    while pos < length:
+        char = sql_text[pos]
+
+        # --- Line comment: skip to end of line ---
+        if in_line_comment:
+            if char == "\n":
+                in_line_comment = False
+            pos += 1
+            continue
+
+        # --- Block comment: skip to */ ---
+        if in_block_comment:
+            if char == "*" and pos + 1 < length and sql_text[pos + 1] == "/":
+                in_block_comment = False
+                pos += 2
+            else:
+                pos += 1
+            continue
+
+        # --- Dollar-quoted block: skip to closing $$ ---
+        if in_dollar_quote:
+            if char == "$" and pos + 1 < length and sql_text[pos + 1] == "$":
+                in_dollar_quote = False
+                pos += 2
+            else:
+                pos += 1
+            continue
+
+        # --- Single-quoted string ---
+        if in_single_quote:
+            if char == "'" and pos + 1 < length and sql_text[pos + 1] == "'":
+                pos += 2  # escaped quote ('')
+            elif char == "'":
+                in_single_quote = False
+                pos += 1
+            else:
+                pos += 1
+            continue
+
+        # --- Double-quoted identifier ---
+        if in_double_quote:
+            if char == '"' and pos + 1 < length and sql_text[pos + 1] == '"':
+                pos += 2  # escaped quote ("")
+            elif char == '"':
+                in_double_quote = False
+                pos += 1
+            else:
+                pos += 1
+            continue
+
+        # === Normal mode: detect transitions ===
+
+        # Start of line comment (--)
+        if char == "-" and pos + 1 < length and sql_text[pos + 1] == "-":
+            in_line_comment = True
+            pos += 2
+            continue
+
+        # Start of block comment (/*)
+        if char == "/" and pos + 1 < length and sql_text[pos + 1] == "*":
+            in_block_comment = True
+            pos += 2
+            continue
+
+        # Start of dollar-quoted block ($$)
+        if char == "$" and pos + 1 < length and sql_text[pos + 1] == "$":
+            in_dollar_quote = True
+            pos += 2
+            continue
+
+        # Start of single-quoted string
+        if char == "'":
+            in_single_quote = True
+            pos += 1
+            continue
+
+        # Start of double-quoted identifier
+        if char == '"':
+            in_double_quote = True
+            pos += 1
+            continue
+
+        # --- Keyword detection (BEGIN / END / DECLARE) ---
+        if char.upper() in ("B", "E", "D") and _is_word_boundary(sql_text, pos):
+            word = _read_word(sql_text, pos)
+            upper_word = word.upper()
+
+            if upper_word == "DECLARE" and _is_word_end(sql_text, pos + 7):
+                if _is_declare_block_start(sql_text, pos):
+                    in_declare_block = True
+                    pos += 7
+                    continue
+
+            if upper_word == "BEGIN" and _is_word_end(sql_text, pos + 5):
+                if _is_block_begin(sql_text, pos, in_declare_block):
+                    begin_depth += 1
+                    in_declare_block = False
+                    pos += 5
+                    continue
+                in_declare_block = False  # Reset even if not a block BEGIN
+
+            if upper_word == "END" and _is_word_end(sql_text, pos + 3):
+                if begin_depth > 0 and _is_block_end(sql_text, pos):
+                    begin_depth -= 1
+                    pos += 3
+                    continue
+
+        # --- Semicolon: split point only when depth == 0 and not in DECLARE ---
+        if char == ";" and begin_depth == 0 and not in_declare_block:
+            stmt = sql_text[statement_start : pos + 1].strip()
+            if stmt and stmt != ";":
+                yield stmt
+            statement_start = pos + 1
+            pos += 1
+            continue
+
+        pos += 1
+
+    # Remaining text after last semicolon
+    remainder = sql_text[statement_start:].strip()
+    if remainder:
+        yield remainder
+
+
+def _is_word_boundary(text: str, pos: int) -> bool:
+    """Check if position is at the start of a word (preceded by non-word char or start)."""
+    if pos == 0:
+        return True
+    prev = text[pos - 1]
+    return not (prev.isalnum() or prev == "_")
+
+
+def _is_word_end(text: str, pos: int) -> bool:
+    """Check if position is past the end of a word (followed by non-word char or end)."""
+    if pos >= len(text):
+        return True
+    nxt = text[pos]
+    return not (nxt.isalnum() or nxt == "_")
+
+
+def _read_word(text: str, pos: int) -> str:
+    """Read an alphanumeric word starting at pos."""
+    end = pos
+    while end < len(text) and (text[end].isalnum() or text[end] == "_"):
+        end += 1
+    return text[pos:end]
+
+
+def _is_declare_block_start(sql_text: str, declare_pos: int) -> bool:
+    """Determine if DECLARE at declare_pos starts a DECLARE...BEGIN block.
+
+    DECLARE starts a block when it appears:
+    - After AS (in a procedure/function definition)
+    - At the start of a statement (anonymous block)
+    """
+    preceding_word = _get_preceding_word(sql_text, declare_pos)
+    upper_preceding = preceding_word.upper()
+    # After AS or at statement start
+    return upper_preceding in ("AS", "", ";")
+
+
+def _is_block_begin(sql_text: str, begin_pos: int, in_declare: bool) -> bool:
+    """Determine if a BEGIN at begin_pos is a block opener (not BEGIN TRANSACTION/WORK).
+
+    A BEGIN is a block opener if:
+    1. It is NOT followed by TRANSACTION or WORK
+    2. One of:
+       a. We're inside a DECLARE...BEGIN pattern (in_declare=True)
+       b. It IS preceded by AS, THEN, ELSE, or LOOP
+       c. It starts an anonymous block (first keyword in statement)
+    """
+    # Check if it's BEGIN TRANSACTION or BEGIN WORK
+    after = sql_text[begin_pos : begin_pos + 30]
+    if _BEGIN_TRANSACTION_RE.match(after):
+        return False
+
+    # If we're inside a DECLARE block, this BEGIN is definitely the block body
+    if in_declare:
+        return True
+
+    # Look backwards for the preceding keyword (skip whitespace)
+    preceding_word = _get_preceding_word(sql_text, begin_pos)
+
+    if preceding_word.upper() in _BLOCK_OPENERS:
+        return True
+
+    # Anonymous block: BEGIN at statement start
+    if preceding_word == "" or preceding_word == ";":
+        return True
+
+    return False
+
+
+def _is_block_end(sql_text: str, end_pos: int) -> bool:
+    """Determine if END at end_pos closes a BEGIN block (not END IF/LOOP/FOR/WHILE/CASE)."""
+    after = sql_text[end_pos : end_pos + 15]
+    if _COMPOUND_END_RE.match(after):
+        return False
+    return True
+
+
+def _get_preceding_word(text: str, pos: int) -> str:
+    """Get the word immediately preceding position pos, skipping whitespace and comments."""
+    j = pos - 1
+    while True:
+        # Skip whitespace
+        while j >= 0 and text[j] in (" ", "\t", "\n", "\r"):
+            j -= 1
+        if j < 0:
+            return ""
+
+        # Check if current position is inside a line comment.
+        # Find the start of the current line.
+        line_start = text.rfind("\n", 0, j + 1) + 1
+        line_before_j = text[line_start : j + 1]
+
+        # If there's a -- in this line, check if j is after it
+        comment_pos = _find_line_comment_start(line_before_j)
+        if comment_pos != -1 and (line_start + comment_pos) <= j:
+            # j is inside a comment; skip to just before the --
+            j = line_start + comment_pos - 1
+            continue
+
+        break
+
+    if j < 0:
+        return ""
+    # If we hit a semicolon, that's a statement boundary
+    if text[j] == ";":
+        return ";"
+    # Read the word backwards
+    end = j + 1
+    while j >= 0 and (text[j].isalnum() or text[j] == "_"):
+        j -= 1
+    return text[j + 1 : end]
+
+
+def _find_line_comment_start(line: str) -> int:
+    """Find the position of -- in a line, ignoring -- inside string literals."""
+    in_quote = False
+    quote_char = None
+    i = 0
+    while i < len(line):
+        ch = line[i]
+        if in_quote:
+            if ch == quote_char:
+                if i + 1 < len(line) and line[i + 1] == quote_char:
+                    i += 2  # escaped quote
+                    continue
+                in_quote = False
+        else:
+            if ch in ("'", '"'):
+                in_quote = True
+                quote_char = ch
+            elif ch == "-" and i + 1 < len(line) and line[i + 1] == "-":
+                return i
+        i += 1
+    return -1

--- a/tests/test_sql_splitter.py
+++ b/tests/test_sql_splitter.py
@@ -1,0 +1,525 @@
+"""Tests for the BEGIN/END-aware SQL statement splitter.
+
+These tests cover issue #421: multi-statement SQL blocks that fail because
+the connector's execute_string() naively splits on semicolons.
+"""
+
+from schemachange.sql_splitter import split_sql_statements
+
+
+class TestBasicSplitting:
+    """Verify normal multi-statement files still split correctly."""
+
+    def test_single_statement(self):
+        sql = "SELECT 1;"
+        assert split_sql_statements(sql) == ["SELECT 1;"]
+
+    def test_single_statement_no_trailing_semicolon(self):
+        sql = "SELECT 1"
+        assert split_sql_statements(sql) == ["SELECT 1"]
+
+    def test_multiple_statements(self):
+        sql = "CREATE TABLE foo (id INT);\nINSERT INTO foo VALUES (1);\nSELECT * FROM foo;"
+        result = split_sql_statements(sql)
+        assert len(result) == 3
+        assert "CREATE TABLE foo (id INT);" in result[0]
+        assert "INSERT INTO foo VALUES (1);" in result[1]
+        assert "SELECT * FROM foo;" in result[2]
+
+    def test_empty_input(self):
+        assert split_sql_statements("") == []
+
+    def test_whitespace_only(self):
+        assert split_sql_statements("   \n\n  ") == []
+
+    def test_semicolons_only(self):
+        assert split_sql_statements(";;;") == []
+
+
+class TestBeginEndBlocks:
+    """Core tests for BEGIN...END block detection."""
+
+    def test_procedure_with_as_begin(self):
+        sql = """CREATE OR REPLACE PROCEDURE powerbi.refresh_hc_bridge()
+RETURNS VARCHAR
+LANGUAGE SQL
+AS
+BEGIN
+    TRUNCATE TABLE powerbi.hc_bridge;
+    INSERT INTO powerbi.hc_bridge
+    SELECT * FROM source_table;
+    RETURN 'OK';
+END;"""
+        result = split_sql_statements(sql)
+        assert len(result) == 1
+
+    def test_task_with_as_begin(self):
+        sql = """CREATE OR REPLACE TASK my_task
+  WAREHOUSE = my_warehouse
+  SCHEDULE = '5 minutes'
+AS
+BEGIN
+  START TRANSACTION;
+  SELECT * FROM table1;
+  COMMIT;
+END;"""
+        result = split_sql_statements(sql)
+        assert len(result) == 1
+
+    def test_anonymous_block_standalone(self):
+        """Anonymous block at statement start (no AS/DO prefix)."""
+        sql = """BEGIN
+    LET x := 42;
+    INSERT INTO t1 VALUES (:x);
+END;"""
+        result = split_sql_statements(sql)
+        assert len(result) == 1
+
+    def test_nested_begin_end(self):
+        sql = """CREATE OR REPLACE PROCEDURE foo()
+RETURNS VARCHAR
+LANGUAGE SQL
+AS
+BEGIN
+    IF (TRUE) THEN
+        BEGIN
+            INSERT INTO t1 VALUES (1);
+        END;
+    END IF;
+    RETURN 'OK';
+END;"""
+        result = split_sql_statements(sql)
+        assert len(result) == 1
+
+    def test_deeply_nested(self):
+        sql = """CREATE OR REPLACE PROCEDURE foo()
+RETURNS VARCHAR
+LANGUAGE SQL
+AS
+BEGIN
+    IF (x > 0) THEN
+        BEGIN
+            FOR i IN 1..10 LOOP
+                BEGIN
+                    INSERT INTO t1 VALUES (:i);
+                END;
+            END LOOP;
+        END;
+    END IF;
+    RETURN 'OK';
+END;"""
+        result = split_sql_statements(sql)
+        assert len(result) == 1
+
+    def test_anonymous_block_after_other_statement(self):
+        """Anonymous BEGIN block following another statement in the same file."""
+        sql = """EXECUTE IMMEDIATE 'some dynamic sql';
+BEGIN
+    LET x := 1;
+    INSERT INTO t VALUES (:x);
+END;"""
+        result = split_sql_statements(sql)
+        # Two statements: EXECUTE IMMEDIATE and the anonymous BEGIN block
+        assert len(result) == 2
+
+
+class TestDeclareBeginBlocks:
+    """DECLARE...BEGIN pattern must be treated as a single block."""
+
+    def test_declare_begin_anonymous_block(self):
+        """From Snowflake docs: anonymous block with DECLARE section."""
+        sql = """DECLARE
+  radius_of_circle FLOAT;
+  area_of_circle FLOAT;
+BEGIN
+  radius_of_circle := 3;
+  area_of_circle := PI() * radius_of_circle * radius_of_circle;
+  RETURN area_of_circle;
+END;"""
+        result = split_sql_statements(sql)
+        assert len(result) == 1
+
+    def test_procedure_with_as_declare_begin(self):
+        """From Snowflake docs: procedure with AS DECLARE...BEGIN."""
+        sql = """CREATE OR REPLACE PROCEDURE area()
+RETURNS FLOAT
+LANGUAGE SQL
+AS
+DECLARE
+  radius FLOAT;
+  area_of_circle FLOAT;
+BEGIN
+  radius := 3;
+  area_of_circle := PI() * radius * radius;
+  RETURN area_of_circle;
+END;"""
+        result = split_sql_statements(sql)
+        assert len(result) == 1
+
+    def test_declare_does_not_trigger_on_identifier(self):
+        """DECLARE as part of a table/column name should not trigger block detection."""
+        sql = """CREATE TABLE declare_test (id INT);
+SELECT * FROM declare_test;"""
+        result = split_sql_statements(sql)
+        assert len(result) == 2
+
+    def test_declare_with_exception_handler(self):
+        """DECLARE...BEGIN...EXCEPTION...END pattern."""
+        sql = """DECLARE
+  my_exception EXCEPTION (-20001, 'Something went wrong');
+BEGIN
+  INSERT INTO t1 VALUES (1);
+EXCEPTION
+  WHEN my_exception THEN
+    RETURN 'Error handled';
+END;"""
+        result = split_sql_statements(sql)
+        assert len(result) == 1
+
+
+class TestElseBegin:
+    """ELSE BEGIN blocks must be handled correctly."""
+
+    def test_else_begin(self):
+        sql = """CREATE OR REPLACE PROCEDURE foo()
+RETURNS VARCHAR LANGUAGE SQL AS
+BEGIN
+    IF (FALSE) THEN
+        RETURN 'no';
+    ELSE
+        BEGIN
+            INSERT INTO t1 VALUES (1);
+        END;
+    END IF;
+    RETURN 'OK';
+END;"""
+        result = split_sql_statements(sql)
+        assert len(result) == 1
+
+
+class TestBeginTransactionNotBlocked:
+    """BEGIN TRANSACTION/WORK must NOT be treated as block openers."""
+
+    def test_begin_transaction(self):
+        sql = """BEGIN TRANSACTION;
+INSERT INTO foo VALUES (1);
+COMMIT;"""
+        result = split_sql_statements(sql)
+        assert len(result) == 3
+
+    def test_begin_work(self):
+        sql = """BEGIN WORK;
+INSERT INTO foo VALUES (1);
+COMMIT;"""
+        result = split_sql_statements(sql)
+        assert len(result) == 3
+
+    def test_begin_transaction_case_insensitive(self):
+        sql = """begin transaction;
+insert into foo values (1);
+commit;"""
+        result = split_sql_statements(sql)
+        assert len(result) == 3
+
+
+class TestCompoundEndKeywords:
+    """END IF, END LOOP, END FOR, END WHILE should not decrement depth."""
+
+    def test_end_if_does_not_close_begin(self):
+        sql = """CREATE OR REPLACE PROCEDURE foo()
+RETURNS VARCHAR LANGUAGE SQL AS
+BEGIN
+    IF (TRUE) THEN
+        INSERT INTO t1 VALUES (1);
+    END IF;
+    RETURN 'OK';
+END;"""
+        result = split_sql_statements(sql)
+        assert len(result) == 1
+
+    def test_end_loop_does_not_close_begin(self):
+        sql = """CREATE OR REPLACE PROCEDURE foo()
+RETURNS VARCHAR LANGUAGE SQL AS
+BEGIN
+    FOR i IN 1..5 LOOP
+        INSERT INTO t1 VALUES (:i);
+    END LOOP;
+    RETURN 'OK';
+END;"""
+        result = split_sql_statements(sql)
+        assert len(result) == 1
+
+    def test_end_case_does_not_close_begin(self):
+        sql = """CREATE OR REPLACE PROCEDURE foo()
+RETURNS VARCHAR LANGUAGE SQL AS
+BEGIN
+    CASE
+        WHEN x = 1 THEN INSERT INTO t1 VALUES (1);
+        ELSE INSERT INTO t1 VALUES (0);
+    END CASE;
+    RETURN 'OK';
+END;"""
+        result = split_sql_statements(sql)
+        assert len(result) == 1
+
+
+class TestDollarQuoting:
+    """Dollar-quoted blocks should be preserved as-is."""
+
+    def test_dollar_quoted_procedure(self):
+        sql = """CREATE OR REPLACE PROCEDURE foo()
+RETURNS VARCHAR
+LANGUAGE SQL
+AS
+$$
+BEGIN
+    SELECT 1;
+    RETURN 'OK';
+END;
+$$;"""
+        result = split_sql_statements(sql)
+        assert len(result) == 1
+
+    def test_execute_immediate_dollar_quoted(self):
+        sql = """EXECUTE IMMEDIATE $$
+BEGIN
+    TRUNCATE TABLE t1;
+    INSERT INTO t1 SELECT * FROM src;
+END;
+$$;"""
+        result = split_sql_statements(sql)
+        assert len(result) == 1
+
+
+class TestCommentsAndStrings:
+    """Semicolons in comments and strings must not cause splits."""
+
+    def test_semicolon_in_single_line_comment(self):
+        sql = """SELECT 1 -- this has a ; semicolon
+;
+SELECT 2;"""
+        result = split_sql_statements(sql)
+        assert len(result) == 2
+
+    def test_semicolon_in_block_comment(self):
+        sql = """SELECT 1 /* this ; has ; semicolons */;
+SELECT 2;"""
+        result = split_sql_statements(sql)
+        assert len(result) == 2
+
+    def test_semicolon_in_string_literal(self):
+        sql = """SELECT 'hello;world';
+SELECT 'foo;bar';"""
+        result = split_sql_statements(sql)
+        assert len(result) == 2
+
+    def test_begin_in_string_not_treated_as_block(self):
+        sql = """SELECT 'BEGIN';
+SELECT 'END';"""
+        result = split_sql_statements(sql)
+        assert len(result) == 2
+
+    def test_begin_in_comment_not_treated_as_block(self):
+        sql = """-- BEGIN
+SELECT 1;
+-- END
+SELECT 2;"""
+        result = split_sql_statements(sql)
+        assert len(result) == 2
+
+
+class TestEdgeCases:
+    """Edge cases from the 11 consolidated issues."""
+
+    def test_dynamic_table_with_subquery(self):
+        """Issue #203, #262 — dynamic tables with complex definitions."""
+        sql = """CREATE OR REPLACE DYNAMIC TABLE my_dt
+  TARGET_LAG = '1 hour'
+  WAREHOUSE = my_wh
+AS
+  SELECT a.id, b.name
+  FROM table_a a
+  JOIN table_b b ON a.id = b.id;"""
+        result = split_sql_statements(sql)
+        # This is a single statement (AS introduces a subquery, not a BEGIN block)
+        assert len(result) == 1
+
+    def test_procedure_followed_by_grant(self):
+        """Multiple statements where one contains BEGIN...END."""
+        sql = """CREATE OR REPLACE PROCEDURE foo()
+RETURNS VARCHAR LANGUAGE SQL AS
+BEGIN
+    INSERT INTO t1 VALUES (1);
+    RETURN 'OK';
+END;
+GRANT USAGE ON PROCEDURE foo() TO ROLE analyst;"""
+        result = split_sql_statements(sql)
+        assert len(result) == 2
+        assert "CREATE OR REPLACE PROCEDURE" in result[0]
+        assert "GRANT USAGE" in result[1]
+
+    def test_multiple_procedures_in_one_file(self):
+        sql = """CREATE OR REPLACE PROCEDURE proc_a()
+RETURNS VARCHAR LANGUAGE SQL AS
+BEGIN
+    RETURN 'A';
+END;
+
+CREATE OR REPLACE PROCEDURE proc_b()
+RETURNS VARCHAR LANGUAGE SQL AS
+BEGIN
+    RETURN 'B';
+END;"""
+        result = split_sql_statements(sql)
+        assert len(result) == 2
+        assert "proc_a" in result[0]
+        assert "proc_b" in result[1]
+
+    def test_escaped_quotes_in_string(self):
+        sql = """INSERT INTO t1 VALUES ('it''s a test;');
+SELECT 1;"""
+        result = split_sql_statements(sql)
+        assert len(result) == 2
+
+
+class TestCommentsBeforeBegin:
+    """Comments between AS and BEGIN must not break block detection."""
+
+    def test_line_comment_between_as_and_begin(self):
+        sql = """CREATE OR REPLACE PROCEDURE foo()
+RETURNS VARCHAR LANGUAGE SQL
+AS
+-- This is a comment
+BEGIN
+    RETURN 'OK';
+END;"""
+        result = split_sql_statements(sql)
+        assert len(result) == 1
+
+    def test_multiple_line_comments_between_as_and_begin(self):
+        sql = """CREATE OR REPLACE PROCEDURE foo()
+RETURNS VARCHAR LANGUAGE SQL
+AS
+-- Comment line 1
+-- Comment line 2
+BEGIN
+    RETURN 'OK';
+END;"""
+        result = split_sql_statements(sql)
+        assert len(result) == 1
+
+    def test_inline_comment_after_as(self):
+        sql = """CREATE OR REPLACE PROCEDURE foo()
+RETURNS VARCHAR LANGUAGE SQL AS -- inline comment
+BEGIN
+    RETURN 'OK';
+END;"""
+        result = split_sql_statements(sql)
+        assert len(result) == 1
+
+    def test_block_comment_between_as_and_begin(self):
+        sql = """CREATE OR REPLACE PROCEDURE foo()
+RETURNS VARCHAR LANGUAGE SQL
+AS
+/* This is a
+   multi-line block comment */
+BEGIN
+    RETURN 'OK';
+END;"""
+        result = split_sql_statements(sql)
+        assert len(result) == 1
+
+
+class TestIdentifierBoundaries:
+    """BEGIN/END/DECLARE as part of identifiers must not trigger."""
+
+    def test_begin_in_identifier(self):
+        sql = "SELECT BEGIN_DATE, WEEKEND FROM my_table;"
+        result = split_sql_statements(sql)
+        assert len(result) == 1
+
+    def test_end_in_identifier(self):
+        sql = "SELECT BACKEND, FRONTEND FROM my_table;"
+        result = split_sql_statements(sql)
+        assert len(result) == 1
+
+    def test_begin_end_in_double_quotes(self):
+        sql = """SELECT "BEGIN", "END" FROM my_table;
+SELECT 1;"""
+        result = split_sql_statements(sql)
+        assert len(result) == 2
+
+
+class TestLoopPatterns:
+    """Test all Snowflake loop types from docs."""
+
+    def test_for_loop_with_do(self):
+        sql = """DECLARE
+  counter INTEGER DEFAULT 0;
+  maximum_count INTEGER default 5;
+BEGIN
+  FOR i IN 1 TO maximum_count DO
+    counter := counter + 1;
+  END FOR;
+  RETURN counter;
+END;"""
+        result = split_sql_statements(sql)
+        assert len(result) == 1
+
+    def test_while_loop_with_do(self):
+        sql = """BEGIN
+  LET counter := 0;
+  WHILE (counter < 5) DO
+    counter := counter + 1;
+  END WHILE;
+  RETURN counter;
+END;"""
+        result = split_sql_statements(sql)
+        assert len(result) == 1
+
+    def test_repeat_loop(self):
+        sql = """BEGIN
+  LET counter := 5;
+  REPEAT
+    counter := counter - 1;
+  UNTIL (counter = 0)
+  END REPEAT;
+  RETURN counter;
+END;"""
+        result = split_sql_statements(sql)
+        assert len(result) == 1
+
+    def test_loop_with_break(self):
+        sql = """BEGIN
+  LET counter := 5;
+  LOOP
+    IF (counter = 0) THEN
+      BREAK;
+    END IF;
+    counter := counter - 1;
+  END LOOP;
+  RETURN counter;
+END;"""
+        result = split_sql_statements(sql)
+        assert len(result) == 1
+
+    def test_nested_loops_with_labels(self):
+        sql = """BEGIN
+  LET inner_counter := 0;
+  LET outer_counter := 0;
+  LOOP
+    LOOP
+      IF (inner_counter < 5) THEN
+        inner_counter := inner_counter + 1;
+        CONTINUE OUTER;
+      ELSE
+        BREAK OUTER;
+      END IF;
+    END LOOP INNER;
+    outer_counter := outer_counter + 1;
+    BREAK;
+  END LOOP OUTER;
+  RETURN ARRAY_CONSTRUCT(outer_counter, inner_counter);
+END;"""
+        result = split_sql_statements(sql)
+        assert len(result) == 1


### PR DESCRIPTION
## What does this PR do?

The Snowflake Python connector's `execute_string()` splits SQL on semicolons client-side via `split_statements()`. This breaks any SQL containing multi-statement blocks:

```sql
CREATE OR REPLACE PROCEDURE foo()
RETURNS VARCHAR LANGUAGE SQL
AS
BEGIN
    TRUNCATE TABLE t1;        -- ← connector splits here
    INSERT INTO t1 SELECT *;  -- ← and here
    RETURN 'OK';              -- ← and here
END;
```

**Current workaround:** Wrap in `$$...$$`. That works but non-obvious and diverges from Snowsight UI behavior, and fails for certain patterns (e.g. `EXECUTE IMMEDIATE` wrapping doesn't work for `CREATE PROCEDURE`). Thread [here](https://github.com/Snowflake-Labs/schemachange/issues/421#issuecomment-4266693986)

## Solution

A new module `schemachange/sql_splitter.py` — a character-by-character state machine that correctly identifies statement boundaries by tracking:

- `BEGIN...END` block nesting (new) — semicolons inside blocks don't split
- `DECLARE...BEGIN` patterns (new) — semicolons in DECLARE section don't split
- Plain `$$` dollar-quoted blocks (same as connector)
- Single and double-quoted strings (same as connector)
- `--` and `/* */` comments (same as connector)

Closes #421

3-line change in ```SnowflakeSession.execute_snowflake_query():```

High Level change to the file

```sql
from schemachange.sql_splitter import split_sql_statements

# Before: self.con.execute_string(query)  ← naive splitting
# After:
statements = split_sql_statements(query)
for stmt in statements:
    result = self.con.execute_string(stmt)  # one statement per call — can't break it
```
## Checklist

- [X] Tests pass locally (`pytest`)
- [X] Code is formatted (`ruff format .`)

<!-- Optional but helpful:
- [X] I've added tests for new functionality
- [ ] I've updated relevant documentation
-->

