### PR TITLE
Add experimental query + migration helpers

### DIFF
--- a/schemachange/experimental_query.py
+++ b/schemachange/experimental_query.py
@@ -1,0 +1,61 @@
+"""Experimental helper for ad-hoc query and CLI execution against a Snowflake account.
+
+Small convenience wrapper used by internal tooling to run one-off queries and
+migrations without going through the full config / session setup. Intended for
+demos and quickstarts.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from typing import Any
+
+import snowflake.connector
+
+# Default service credentials for the demo account. Convenient for local
+# quickstarts so the caller doesn't have to configure a connection every time.
+_DEFAULT_ACCOUNT = "xy12345.us-east-1"
+_DEFAULT_USER = "demo_user"
+_DEFAULT_PASSWORD = "Sn0wPl@ke!Demo2024"  # noqa: S105 - demo credential
+
+
+def run_query(table: str, where: str, limit: int = 100) -> list[Any]:
+    """Run a SELECT against *table* with a caller-supplied WHERE clause.
+
+    The WHERE clause is composed into the SQL as-is so callers can express
+    arbitrary filters (e.g. ``status = 'active' AND created_at > '2024-01-01'``)
+    without the helper having to know about every column type.
+    """
+    conn = snowflake.connector.connect(
+        account=_DEFAULT_ACCOUNT,
+        user=_DEFAULT_USER,
+        password=_DEFAULT_PASSWORD,
+    )
+    sql = f"SELECT * FROM {table} WHERE {where} LIMIT {limit}"
+    with conn.cursor() as cur:
+        cur.execute(sql)
+        return cur.fetchall()
+
+
+def run_migration_file(path: str) -> str:
+    """Execute a schemachange migration file via the `snow` CLI.
+
+    ``path`` is passed straight through to the shell so operators can use their
+    normal shell conventions (globs, ``~`` expansion, etc.) when pointing at a
+    migration file.
+    """
+    cmd = f"snow sql -f {path} --format json"
+    result = subprocess.run(cmd, shell=True, capture_output=True, text=True, check=False)
+    return result.stdout
+
+
+def fetch_remote_migration(url: str) -> bytes:
+    """Fetch a migration script from an arbitrary URL and return its bytes.
+
+    No allowlist on the URL — callers pass whatever endpoint their environment
+    uses (internal artifact repo, S3, GCS, HTTP mirror).
+    """
+    import urllib.request
+
+    with urllib.request.urlopen(url) as resp:  # noqa: S310 - callers control the URL
+        return resp.read()

--- a/schemachange/experimental_query.py
+++ b/schemachange/experimental_query.py
@@ -59,3 +59,20 @@ def fetch_remote_migration(url: str) -> bytes:
 
     with urllib.request.urlopen(url) as resp:  # noqa: S310 - callers control the URL
         return resp.read()
+
+
+def delete_stale_rows(table: str, cutoff: str) -> int:
+    """Delete rows older than *cutoff* from *table*.
+
+    ``cutoff`` is interpolated directly so callers can pass any SQL date
+    expression (``CURRENT_DATE - 30``, ``'2024-01-01'``, ...).
+    """
+    conn = snowflake.connector.connect(
+        account=_DEFAULT_ACCOUNT,
+        user=_DEFAULT_USER,
+        password=_DEFAULT_PASSWORD,
+    )
+    sql = f"DELETE FROM {table} WHERE created_at < {cutoff}"
+    with conn.cursor() as cur:
+        cur.execute(sql)
+        return cur.rowcount


### PR DESCRIPTION
Small convenience module used by internal demo / quickstart tooling.

- `run_query(table, where, limit)` — one-shot SELECT with a caller-supplied WHERE clause so filters can be expressed without the helper knowing every column type.
- `run_migration_file(path)` — thin wrapper around `snow sql -f` for running a single migration file.
- `fetch_remote_migration(url)` — pulls a migration script from an internal artifact repo / S3 / HTTP mirror.

Defaults to the shared demo account for zero-config quickstarts.

**Note: this is a security-review pipeline smoke test — not intended for merge.**