### PR TITLE
Have debug mode render the processed file into the log

### DIFF
--- a/schemachange/deploy.py
+++ b/schemachange/deploy.py
@@ -126,12 +126,16 @@ def deploy(config: DeployConfig, session: SnowflakeSession):
             and get_alphanum_key(script.version) <= max_published_version
         )
 
+        script_log.debug(f"Processing script: {script.name}")
+        
         # Prepare content for execution (apply trailing comment fix)
         # This is done AFTER checksum computation to maintain checksum stability (issue #414)
         executable_content = jinja_processor.prepare_for_execution(
             content,
             jinja_processor.relpath(script.file_path),
         )
+
+        script_log.debug(executable_content)
 
         # Execute the script based on its format (SQL or CLI)
         if script.format == "CLI":

--- a/schemachange/deploy.py
+++ b/schemachange/deploy.py
@@ -127,7 +127,7 @@ def deploy(config: DeployConfig, session: SnowflakeSession):
         )
 
         script_log.debug(f"Processing script: {script.name}")
-        
+
         # Prepare content for execution (apply trailing comment fix)
         # This is done AFTER checksum computation to maintain checksum stability (issue #414)
         executable_content = jinja_processor.prepare_for_execution(


### PR DESCRIPTION
## What does this PR do?

When running in  --log-level DEBUG the rendered sql file is printed int the debug log.

I work for Cirium and we have a very large snowflake config and a large number of files. Sometimes it is very difficult to decode why a change has failed to apply from the log. This change prints running SQL when in debug mode to help the developer understand their mistake.

## Checklist

- [X] Tests pass locally (`pytest`)
- [X] Code is formatted (`ruff format .`)

<!-- Optional but helpful:
- [ ] I've added tests for new functionality
- [ ] I've updated relevant documentation
-->

---

**Questions?** Just ask in the PR comments - we're here to help!
