### PR TITLE
fix(security): escape single quotes in reset_query_tag (CWE-89) 

### DIFF
--- a/schemachange/session/SnowflakeSession.py
+++ b/schemachange/session/SnowflakeSession.py
@@ -466,7 +466,9 @@ class SnowflakeSession:
         if extra_tag:
             query_tag += f";{extra_tag}"
 
-        self.execute_snowflake_query(f"ALTER SESSION SET QUERY_TAG = '{query_tag}'", logger=logger)
+        # Escape single quotes to prevent SQL injection via user-controlled config values
+        safe_query_tag = query_tag.replace("'", "''")
+        self.execute_snowflake_query(f"ALTER SESSION SET QUERY_TAG = '{safe_query_tag}'", logger=logger)
 
     def apply_change_script(
         self,


### PR DESCRIPTION
## What does this PR do?

**escape single quotes in reset_query_tag (CWE-89)**

```ALTER SESSION SET QUERY_TAG``` interpolated query_tag (from user config or
extra_tag from filenames) directly into SQL without escaping. A value
containing a single quote could break out of the string literal and
inject arbitrary SQL.

Apply standard SQL single-quote escaping (' -> '') before interpolation.

#446


## Checklist

- [X] Tests pass locally (`pytest`)
- [X] Code is formatted (`ruff format .`)

