### PR TITLE
fix(security): use parameterized queries in record_change_history 

### DIFF
--- a/schemachange/session/SnowflakeSession.py
+++ b/schemachange/session/SnowflakeSession.py
@@ -651,16 +651,26 @@ class SnowflakeSession:
                 STATUS,
                 INSTALLED_BY,
                 INSTALLED_ON
-            ) VALUES (
-                '{getattr(script, "version", "")}',
-                '{script.description}',
-                '{script.name}',
-                '{script.type}',
-                '{checksum}',
-                {execution_time},
-                '{status}',
-                '{self.user}',
-                CURRENT_TIMESTAMP
-            );
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, CURRENT_TIMESTAMP)
         """
-        self.execute_snowflake_query(dedent(query), logger=logger)
+        params = (
+            getattr(script, "version", ""),
+            script.description,
+            script.name,
+            script.type,
+            checksum,
+            execution_time,
+            status,
+            self.user,
+        )
+        logger.debug("Recording change history", params=params)
+        try:
+            with self.con.cursor() as cur:
+                cur.execute(dedent(query), params)
+            if not self.autocommit:
+                self.con.commit()
+        except Exception as e:
+            logger.error("Failed to record change history", error_msg=str(e))
+            if not self.autocommit:
+                self.con.rollback()
+            raise

--- a/schemachange/session/SnowflakeSession.py
+++ b/schemachange/session/SnowflakeSession.py
@@ -258,6 +258,38 @@ class SnowflakeSession:
                 self.con.rollback()
             raise
 
+    def _execute_parameterized(self, query: str, params: tuple, logger: structlog.BoundLogger):
+        """Execute a single parameterized query with bind variables.
+
+        Unlike execute_snowflake_query (which splits on semicolons and uses
+        execute_string for raw SQL), this method uses cursor.execute with bind
+        parameters to safely pass values without SQL injection risk.
+        """
+        logger.debug("Executing parameterized query", query_preview=query[:200])
+
+        try:
+            with self.con.cursor() as cur:
+                cur.execute(query, params)
+            if not self.autocommit:
+                self.con.commit()
+
+        except snowflake.connector.errors.ProgrammingError as e:
+            logger.error(
+                "SQL execution error",
+                error_code=getattr(e, "errno", None),
+                sql_state=getattr(e, "sqlstate", None),
+                error_msg=str(e),
+            )
+            if not self.autocommit:
+                self.con.rollback()
+            raise
+
+        except snowflake.connector.errors.DatabaseError as e:
+            logger.error("Database error", error_type=type(e).__name__, error_msg=str(e))
+            if not self.autocommit:
+                self.con.rollback()
+            raise
+
     def fetch_change_history_metadata(self) -> dict:
         if self.change_history_table is None:
             raise ValueError("change_history_table is required for deployment operations")
@@ -664,13 +696,4 @@ class SnowflakeSession:
             self.user,
         )
         logger.debug("Recording change history", params=params)
-        try:
-            with self.con.cursor() as cur:
-                cur.execute(dedent(query), params)
-            if not self.autocommit:
-                self.con.commit()
-        except Exception as e:
-            logger.error("Failed to record change history", error_msg=str(e))
-            if not self.autocommit:
-                self.con.rollback()
-            raise
+        self._execute_parameterized(dedent(query), params, logger)

--- a/tests/session/test_SnowflakeSession.py
+++ b/tests/session/test_SnowflakeSession.py
@@ -661,6 +661,9 @@ class TestSnowflakeSession:
                 return None
 
             mock_conn.execute_string.side_effect = side_effect_func
+            mock_cursor = mock.Mock()
+            mock_conn.cursor.return_value.__enter__ = mock.Mock(return_value=mock_cursor)
+            mock_conn.cursor.return_value.__exit__ = mock.Mock(return_value=False)
             mock_connect.return_value = mock_conn
 
             with mock.patch("schemachange.session.SnowflakeSession.get_snowflake_identifier_string"):
@@ -725,6 +728,9 @@ class TestSnowflakeSession:
                 return None
 
             mock_conn.execute_string.side_effect = side_effect_func
+            mock_cursor = mock.Mock()
+            mock_conn.cursor.return_value.__enter__ = mock.Mock(return_value=mock_cursor)
+            mock_conn.cursor.return_value.__exit__ = mock.Mock(return_value=False)
             mock_connect.return_value = mock_conn
 
             with mock.patch("schemachange.session.SnowflakeSession.get_snowflake_identifier_string"):
@@ -934,6 +940,71 @@ class TestSnowflakeSession:
 
                 mock_record.assert_called_once()
                 assert mock_record.call_args.kwargs["checksum"] == expected_checksum
+
+    def test_record_change_history_logs_params_at_debug(self):
+        """Verify record_change_history emits a debug log with bind params for debuggability."""
+        change_history_table = ChangeHistoryTable()
+        logger = structlog.testing.CapturingLogger()
+
+        with mock.patch("snowflake.connector.connect") as mock_connect:
+            mock_conn = mock.Mock()
+            mock_conn.account = "test_account"
+            mock_conn.user = "test_user"
+            mock_conn.role = "test_role"
+            mock_conn.warehouse = "test_warehouse"
+            mock_conn.database = "test_db"
+            mock_conn.schema = "test_schema"
+            mock_conn.session_id = "session_123"
+
+            mock_cursor = mock.Mock()
+            mock_conn.cursor.return_value.__enter__ = mock.Mock(return_value=mock_cursor)
+            mock_conn.cursor.return_value.__exit__ = mock.Mock(return_value=False)
+            mock_connect.return_value = mock_conn
+
+            with mock.patch("schemachange.session.SnowflakeSession.get_snowflake_identifier_string"):
+                session = SnowflakeSession(
+                    user="test_user",
+                    account="test_account",
+                    role="test_role",
+                    warehouse="test_warehouse",
+                    database="test_db",
+                    schema_name="test_schema",
+                    schemachange_version="4.3.0",
+                    application="schemachange",
+                    change_history_table=change_history_table,
+                    logger=logger,
+                )
+
+                script = VersionedScript(
+                    version="1.0.0",
+                    description="test migration",
+                    name="V1.0.0__test_migration.sql",
+                    file_path=Path("/scripts/V1.0.0__test_migration.sql"),
+                )
+
+                session.record_change_history(
+                    script=script,
+                    checksum="abc123",
+                    execution_time=5,
+                    status="Success",
+                    logger=logger,
+                )
+
+                # Find the debug log entry for record_change_history
+                debug_calls = [
+                    call
+                    for call in logger.calls
+                    if call.method_name == "debug" and "Recording change history" in str(call.args)
+                ]
+                assert len(debug_calls) == 1, f"Expected 1 debug log, got {len(debug_calls)}"
+
+                logged_kwargs = debug_calls[0].kwargs
+                assert "params" in logged_kwargs, "Debug log should include params for debuggability"
+                assert logged_kwargs["params"][0] == "1.0.0"  # version
+                assert logged_kwargs["params"][1] == "test migration"  # description
+                assert logged_kwargs["params"][2] == "V1.0.0__test_migration.sql"  # script name
+                assert logged_kwargs["params"][5] == 5  # execution_time
+                assert logged_kwargs["params"][6] == "Success"  # status
 
     def test_execute_snowflake_query_logs_programming_error_details(self):
         """Test that execute_snowflake_query logs ProgrammingError details and re-raises."""

--- a/tests/session/test_SnowflakeSession.py
+++ b/tests/session/test_SnowflakeSession.py
@@ -1006,6 +1006,77 @@ class TestSnowflakeSession:
                 assert logged_kwargs["params"][5] == 5  # execution_time
                 assert logged_kwargs["params"][6] == "Success"  # status
 
+    def test_record_change_history_uses_parameterized_query(self):
+        """Verify record_change_history passes values as bind params, not interpolated SQL.
+
+        Regression test for CWE-89: a malicious script description containing SQL
+        injection payload must be passed as a bind parameter to cursor.execute(),
+        never spliced into the SQL string itself.
+        """
+        change_history_table = ChangeHistoryTable()
+        logger = structlog.testing.CapturingLogger()
+
+        with mock.patch("snowflake.connector.connect") as mock_connect:
+            mock_conn = mock.Mock()
+            mock_conn.account = "test_account"
+            mock_conn.user = "test_user"
+            mock_conn.role = "test_role"
+            mock_conn.warehouse = "test_warehouse"
+            mock_conn.database = "test_db"
+            mock_conn.schema = "test_schema"
+            mock_conn.session_id = "session_123"
+
+            mock_cursor = mock.Mock()
+            mock_conn.cursor.return_value.__enter__ = mock.Mock(return_value=mock_cursor)
+            mock_conn.cursor.return_value.__exit__ = mock.Mock(return_value=False)
+            mock_connect.return_value = mock_conn
+
+            with mock.patch("schemachange.session.SnowflakeSession.get_snowflake_identifier_string"):
+                session = SnowflakeSession(
+                    user="test_user",
+                    account="test_account",
+                    role="test_role",
+                    warehouse="test_warehouse",
+                    database="test_db",
+                    schema_name="test_schema",
+                    schemachange_version="4.3.0",
+                    application="schemachange",
+                    change_history_table=change_history_table,
+                    logger=logger,
+                )
+
+                # Malicious payload in description (derived from filename in real usage)
+                injection_payload = "x'; DROP TABLE important_data; --"
+
+                script = VersionedScript(
+                    version="1.0.0",
+                    description=injection_payload,
+                    name="V1.0.0__x.sql",
+                    file_path=Path("/scripts/V1.0.0__x.sql"),
+                )
+
+                session.record_change_history(
+                    script=script,
+                    checksum="abc123",
+                    execution_time=5,
+                    status="Success",
+                    logger=logger,
+                )
+
+                # cursor.execute must have been called with template + params
+                mock_cursor.execute.assert_called_once()
+                call_args = mock_cursor.execute.call_args
+
+                executed_sql = call_args[0][0]
+                bind_params = call_args[0][1]
+
+                # The SQL template must use %s placeholders, not contain the payload
+                assert "%s" in executed_sql, "Query must use bind parameter placeholders"
+                assert injection_payload not in executed_sql, "Injection payload must NOT appear in SQL template"
+
+                # The payload must be safely contained in the params tuple
+                assert injection_payload in bind_params, "Injection payload must be passed as a bind parameter"
+
     def test_execute_snowflake_query_logs_programming_error_details(self):
         """Test that execute_snowflake_query logs ProgrammingError details and re-raises."""
         change_history_table = ChangeHistoryTable()


### PR DESCRIPTION
## What does this PR do? 

#446

The INSERT statement in record_change_history previously used f-string interpolation to embed script metadata (name, description, version) directly into SQL. Because execute_snowflake_query splits on semicolons, a crafted filename containing ```'; DROP TABLE ...' ``` could inject arbitrary SQL.

Replace f-string value interpolation with bind parameters (%s) passed to cursor.execute(), which prevents any value content from being interpreted as SQL syntax or statement separators.

## Checklist

- [X] Tests pass locally (`pytest`)
- [X] Code is formatted (`ruff format .`)

